### PR TITLE
feat: add client-side PDF utilities

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,17 @@
+import '../styles/globals.css';
+import React from 'react';
+
+export const metadata = {
+  title: 'PDF Tool Site',
+  description: 'Client-side PDF utilities'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50 text-gray-900">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/tools/compress/page.tsx
+++ b/app/tools/compress/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+import React, { useState } from 'react';
+import { PDFDocument } from 'pdf-lib';
+import UploadArea from '../../../components/UploadArea';
+
+export default function CompressPage() {
+  const [processing, setProcessing] = useState(false);
+  const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
+  const [quality, setQuality] = useState(0.7);
+
+  const handleFiles = async (files: FileList) => {
+    const file = files[0];
+    if (!file) return;
+    setProcessing(true);
+    try {
+      const bytes = await file.arrayBuffer();
+      const pdf = await PDFDocument.load(bytes);
+      const compressedBytes = await pdf.save({ useObjectStreams: true });
+      const blob = new Blob([compressedBytes], { type: 'application/pdf' });
+      setDownloadUrl(URL.createObjectURL(blob));
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Compress PDF</h1>
+      <div>
+        <label className="mr-2">Quality:</label>
+        <input
+          type="range"
+          min={0.1}
+          max={1}
+          step={0.1}
+          value={quality}
+          onChange={(e) => setQuality(parseFloat(e.target.value))}
+        />
+        <span className="ml-2">{quality}</span>
+      </div>
+      <UploadArea onFiles={handleFiles} accept="application/pdf" />
+      {processing && <p>Processing...</p>}
+      {downloadUrl && (
+        <a
+          href={downloadUrl}
+          download="compressed.pdf"
+          className="inline-block mt-4 px-4 py-2 bg-green-600 text-white rounded"
+        >
+          Download
+        </a>
+      )}
+    </div>
+  );
+}

--- a/app/tools/extract-text/page.tsx
+++ b/app/tools/extract-text/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+import React, { useState } from 'react';
+import UploadArea from '../../../components/UploadArea';
+import { getDocument, GlobalWorkerOptions } from 'pdfjs-dist';
+import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.min.js';
+import Tesseract from 'tesseract.js';
+
+GlobalWorkerOptions.workerSrc = pdfjsWorker;
+
+export default function ExtractTextPage() {
+  const [processing, setProcessing] = useState(false);
+  const [text, setText] = useState('');
+  const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
+
+  const handleFiles = async (files: FileList) => {
+    const file = files[0];
+    if (!file) return;
+    setProcessing(true);
+    try {
+      const bytes = await file.arrayBuffer();
+      const loadingTask = getDocument({ data: bytes });
+      const pdf = await loadingTask.promise;
+      let result = '';
+      for (let i = 1; i <= pdf.numPages; i++) {
+        const page = await pdf.getPage(i);
+        const viewport = page.getViewport({ scale: 2 });
+        const canvas = document.createElement('canvas');
+        const context = canvas.getContext('2d')!;
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+        await page.render({ canvasContext: context, viewport }).promise;
+        const { data } = await Tesseract.recognize(canvas, 'eng');
+        result += data.text + '\n';
+      }
+      setText(result);
+      const blob = new Blob([result], { type: 'text/plain' });
+      setDownloadUrl(URL.createObjectURL(blob));
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Extract Text</h1>
+      <UploadArea onFiles={handleFiles} accept="application/pdf" />
+      {processing && <p>Processing...</p>}
+      {text && (
+        <textarea value={text} readOnly className="w-full h-48 border p-2" />
+      )}
+      {downloadUrl && (
+        <a
+          href={downloadUrl}
+          download="extracted.txt"
+          className="inline-block mt-4 px-4 py-2 bg-green-600 text-white rounded"
+        >
+          Download
+        </a>
+      )}
+    </div>
+  );
+}

--- a/app/tools/extract-text/page.tsx
+++ b/app/tools/extract-text/page.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import UploadArea from '../../../components/UploadArea';
 import { getDocument, GlobalWorkerOptions } from 'pdfjs-dist';
-import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.min.js';
+import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.min.js?url';
 import Tesseract from 'tesseract.js';
 
 GlobalWorkerOptions.workerSrc = pdfjsWorker;

--- a/app/tools/extract-text/page.tsx
+++ b/app/tools/extract-text/page.tsx
@@ -2,10 +2,10 @@
 import React, { useState } from 'react';
 import UploadArea from '../../../components/UploadArea';
 import { getDocument, GlobalWorkerOptions } from 'pdfjs-dist';
-import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.min.js?url';
 import Tesseract from 'tesseract.js';
 
-GlobalWorkerOptions.workerSrc = pdfjsWorker;
+GlobalWorkerOptions.workerSrc =
+  'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.3.136/pdf.worker.min.js';
 
 export default function ExtractTextPage() {
   const [processing, setProcessing] = useState(false);

--- a/app/tools/image-to-pdf/page.tsx
+++ b/app/tools/image-to-pdf/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+import React, { useState } from 'react';
+import { PDFDocument } from 'pdf-lib';
+import UploadArea from '../../../components/UploadArea';
+
+export default function ImageToPdfPage() {
+  const [processing, setProcessing] = useState(false);
+  const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
+
+  const handleFiles = async (files: FileList) => {
+    setProcessing(true);
+    try {
+      const pdfDoc = await PDFDocument.create();
+      for (const file of Array.from(files)) {
+        const bytes = await file.arrayBuffer();
+        let image;
+        if (file.type === 'image/png') {
+          image = await pdfDoc.embedPng(bytes);
+        } else {
+          image = await pdfDoc.embedJpg(bytes);
+        }
+        const page = pdfDoc.addPage([image.width, image.height]);
+        page.drawImage(image, {
+          x: 0,
+          y: 0,
+          width: image.width,
+          height: image.height,
+        });
+      }
+      const pdfBytes = await pdfDoc.save();
+      const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+      setDownloadUrl(URL.createObjectURL(blob));
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Image to PDF</h1>
+      <UploadArea onFiles={handleFiles} accept="image/png,image/jpeg" multiple />
+      {processing && <p>Processing...</p>}
+      {downloadUrl && (
+        <a
+          href={downloadUrl}
+          download="images.pdf"
+          className="inline-block mt-4 px-4 py-2 bg-green-600 text-white rounded"
+        >
+          Download
+        </a>
+      )}
+    </div>
+  );
+}

--- a/app/tools/layout.tsx
+++ b/app/tools/layout.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import React from 'react';
+
+const links = [
+  { href: '/tools/merge', label: 'Merge PDFs' },
+  { href: '/tools/split', label: 'Split PDF' },
+  { href: '/tools/compress', label: 'Compress PDF' },
+  { href: '/tools/image-to-pdf', label: 'Image to PDF' },
+  { href: '/tools/extract-text', label: 'Extract Text' },
+];
+
+export default function ToolsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <nav className="bg-white shadow p-4 flex gap-4 justify-center">
+        {links.map((link) => (
+          <Link key={link.href} href={link.href} className="text-blue-600 hover:underline">
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+      <main className="flex-1 container mx-auto p-4">{children}</main>
+    </div>
+  );
+}

--- a/app/tools/merge/page.tsx
+++ b/app/tools/merge/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+import React, { useState } from 'react';
+import { PDFDocument } from 'pdf-lib';
+import UploadArea from '../../../components/UploadArea';
+
+export default function MergePage() {
+  const [processing, setProcessing] = useState(false);
+  const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
+
+  const handleFiles = async (files: FileList) => {
+    setProcessing(true);
+    try {
+      const mergedPdf = await PDFDocument.create();
+      for (const file of Array.from(files)) {
+        const bytes = await file.arrayBuffer();
+        const pdf = await PDFDocument.load(bytes);
+        const copied = await mergedPdf.copyPages(pdf, pdf.getPageIndices());
+        copied.forEach((p) => mergedPdf.addPage(p));
+      }
+      const mergedBytes = await mergedPdf.save();
+      const blob = new Blob([mergedBytes], { type: 'application/pdf' });
+      setDownloadUrl(URL.createObjectURL(blob));
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Merge PDFs</h1>
+      <UploadArea onFiles={handleFiles} accept="application/pdf" multiple />
+      {processing && <p>Processing...</p>}
+      {downloadUrl && (
+        <a
+          href={downloadUrl}
+          download="merged.pdf"
+          className="inline-block mt-4 px-4 py-2 bg-green-600 text-white rounded"
+        >
+          Download
+        </a>
+      )}
+    </div>
+  );
+}

--- a/app/tools/split/page.tsx
+++ b/app/tools/split/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+import React, { useState } from 'react';
+import { PDFDocument } from 'pdf-lib';
+import UploadArea from '../../../components/UploadArea';
+
+export default function SplitPage() {
+  const [range, setRange] = useState('1-1');
+  const [processing, setProcessing] = useState(false);
+  const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
+
+  const handleFiles = async (files: FileList) => {
+    const file = files[0];
+    if (!file) return;
+    setProcessing(true);
+    try {
+      const [startStr, endStr] = range.split('-');
+      const start = parseInt(startStr, 10) - 1;
+      const end = parseInt(endStr, 10) - 1;
+      const bytes = await file.arrayBuffer();
+      const pdf = await PDFDocument.load(bytes);
+      const newPdf = await PDFDocument.create();
+      const indices = pdf.getPageIndices().slice(start, end + 1);
+      const copied = await newPdf.copyPages(pdf, indices);
+      copied.forEach((p) => newPdf.addPage(p));
+      const newBytes = await newPdf.save();
+      const blob = new Blob([newBytes], { type: 'application/pdf' });
+      setDownloadUrl(URL.createObjectURL(blob));
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Split PDF</h1>
+      <div>
+        <label className="mr-2">Page Range (e.g., 1-3):</label>
+        <input
+          value={range}
+          onChange={(e) => setRange(e.target.value)}
+          className="border p-1"
+        />
+      </div>
+      <UploadArea onFiles={handleFiles} accept="application/pdf" />
+      {processing && <p>Processing...</p>}
+      {downloadUrl && (
+        <a
+          href={downloadUrl}
+          download="split.pdf"
+          className="inline-block mt-4 px-4 py-2 bg-green-600 text-white rounded"
+        >
+          Download
+        </a>
+      )}
+    </div>
+  );
+}

--- a/components/UploadArea.tsx
+++ b/components/UploadArea.tsx
@@ -1,0 +1,47 @@
+'use client';
+import React, { useRef } from 'react';
+
+interface UploadAreaProps {
+  onFiles: (files: FileList) => void;
+  accept?: string;
+  multiple?: boolean;
+}
+
+export default function UploadArea({ onFiles, accept, multiple }: UploadAreaProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = (files: FileList | null) => {
+    if (files && files.length > 0) {
+      onFiles(files);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const handleClick = () => {
+    inputRef.current?.click();
+  };
+
+  return (
+    <div
+      onDrop={handleDrop}
+      onDragOver={(e) => e.preventDefault()}
+      className="border-2 border-dashed border-gray-400 rounded p-10 text-center cursor-pointer"
+      onClick={handleClick}
+    >
+      <p className="mb-2">Drag and drop files here or click to upload.</p>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        multiple={multiple}
+        onChange={(e) => handleFiles(e.target.files)}
+        className="hidden"
+      />
+      <button className="mt-2 px-4 py-2 bg-blue-600 text-white rounded">Select Files</button>
+    </div>
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,11 @@
+/** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
   trailingSlash: false,
+  webpack: (config) => {
+    config.externals = [...(config.externals || []), 'pdfjs-dist'];
+    return config;
+  },
 };
+
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "tesseract.js": "^4.0.2"
   },
   "devDependencies": {
-    "@netlify/plugin-nextjs": "^5.0.0"
+    "@netlify/plugin-nextjs": "^5.0.0",
+    "typescript": "5.2.2",
+    "@types/react": "18.2.37",
+    "@types/node": "20.8.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "postcss": "8.4.31",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "tailwindcss": "3.3.5"
+    "tailwindcss": "3.3.5",
+    "pdfjs-dist": "^4.3.136",
+    "tesseract.js": "^4.0.2"
   },
   "devDependencies": {
     "@netlify/plugin-nextjs": "^5.0.0"


### PR DESCRIPTION
## Summary
- add shared upload component and tools layout
- implement client-side PDF tools: merge, split, compress, image-to-pdf, extract text
- wire up pdf-lib, pdfjs-dist, and tesseract.js

## Testing
- `npm test` *(fails: Module not found: Can't resolve 'pdfjs-dist')*

------
https://chatgpt.com/codex/tasks/task_e_689c29a9f884832fbc9c898e9a288722