### PR TITLE
feat: add ATS-ready CV toolkit

### DIFF
--- a/app/(ats)/ats-toolkit/ats-export/page.tsx
+++ b/app/(ats)/ats-toolkit/ats-export/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+import AppErrorBoundary from '@/components/AppErrorBoundary';
+import { ToastProvider, useToast } from '@/components/toast/ToastProvider';
+import DropZone from '@/components/DropZone';
+import Seo from '@/components/Seo';
+import { extractATSSafeText } from '@/lib/ats/export';
+import { createSampleResumePDF, blobUrl } from '@/lib/samples';
+import { useState, useEffect } from 'react';
+import { track } from '@/lib/analytics';
+
+function Inner() {
+  const toast = useToast();
+  const [text, setText] = useState('');
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => () => { if (url) URL.revokeObjectURL(url); }, [url]);
+
+  const handle = async (files: File[]) => {
+    const file = files[0];
+    if (!file) return;
+    track('file_dropped', { tool: 'ats-export' });
+    const t = await extractATSSafeText(file);
+    setText(t);
+    const blob = new Blob([t], { type: 'text/plain' });
+    const u = blobUrl(blob);
+    setUrl(u);
+    track('task_completed', { tool: 'ats-export' });
+  };
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(text);
+    toast({ message: 'Copied', type: 'success' });
+  };
+
+  const trySample = async () => {
+    const pdf = await createSampleResumePDF();
+    handle([new File([pdf], 'sample.pdf', { type: 'application/pdf' })]);
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <Seo title="ATS Export" description="Extract text" />
+      <h2 className="text-xl font-semibold mb-4">ATS Export</h2>
+      <DropZone accept=".pdf,.docx,.txt,.md" onFiles={handle} onText={(t) => setText(t)} />
+      <button className="mt-4 text-blue-600 underline" onClick={trySample}>
+        Try sample
+      </button>
+      {text && (
+        <div className="mt-4">
+          <pre className="whitespace-pre-wrap bg-gray-100 p-2 rounded max-h-96 overflow-auto">{text}</pre>
+          <div className="mt-2 space-x-4">
+            <button onClick={copy} className="text-blue-600 underline">
+              Copy
+            </button>
+            {url && (
+              <a href={url} download="export.txt" className="text-blue-600 underline">
+                Download .txt
+              </a>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function ATSExportPage() {
+  return (
+    <AppErrorBoundary>
+      <ToastProvider>
+        <Inner />
+      </ToastProvider>
+    </AppErrorBoundary>
+  );
+}

--- a/app/(ats)/ats-toolkit/compress/page.tsx
+++ b/app/(ats)/ats-toolkit/compress/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+import AppErrorBoundary from '@/components/AppErrorBoundary';
+import { ToastProvider, useToast } from '@/components/toast/ToastProvider';
+import DropZone from '@/components/DropZone';
+import Seo from '@/components/Seo';
+import { useQuota } from '@/lib/quota';
+import { track } from '@/lib/analytics';
+import { createSampleResumePDF, blobUrl } from '@/lib/samples';
+import { useState, useEffect } from 'react';
+
+function Inner() {
+  const toast = useToast();
+  const quota = useQuota();
+  const [result, setResult] = useState<Blob | null>(null);
+  const [progress, setProgress] = useState(0);
+  const [before, setBefore] = useState(0);
+  const [after, setAfter] = useState(0);
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => () => { if (url) URL.revokeObjectURL(url); }, [url]);
+
+  const handle = async (files: File[]) => {
+    const file = files[0];
+    if (!file) return;
+    if (!quota.allowed(file.size)) {
+      toast({ message: 'Quota exceeded', type: 'error' });
+      return;
+    }
+    quota.consume(file.size);
+    track('file_dropped', { tool: 'compress' });
+    const worker = new Worker(new URL('../../../../src/workers/compress.worker.ts', import.meta.url), { type: 'module' });
+    worker.onmessage = (e) => {
+      const data = e.data;
+      if (data.progress) setProgress(data.progress);
+      if (data.bytes) {
+        const blob = new Blob([data.bytes], { type: 'application/pdf' });
+        setResult(blob);
+        setBefore(data.beforeSize);
+        setAfter(data.afterSize);
+        const u = blobUrl(blob);
+        setUrl(u);
+        track('task_completed', { tool: 'compress' });
+        toast({ message: `Compressed ${(data.beforeSize/1024).toFixed(1)}KB → ${(data.afterSize/1024).toFixed(1)}KB`, type: 'success' });
+      }
+      if (data.error) toast({ message: data.error, type: 'error' });
+    };
+    worker.postMessage({ pdfBytes: await file.arrayBuffer() });
+  };
+
+  const trySample = async () => {
+    const blob = await createSampleResumePDF();
+    handle([new File([blob], 'sample.pdf', { type: 'application/pdf' })]);
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <Seo title="Compress" description="Shrink PDF size" />
+      <h2 className="text-xl font-semibold mb-4">Compress PDF</h2>
+      <DropZone accept="application/pdf" onFiles={handle} />
+      <button className="mt-4 text-blue-600 underline" onClick={trySample}>
+        Try sample
+      </button>
+      {progress > 0 && progress < 1 && <p className="mt-2">Progress: {(progress*100).toFixed(0)}%</p>}
+      {result && url && (
+        <div className="mt-4">
+          <p>Before: {(before/1024).toFixed(1)}KB After: {(after/1024).toFixed(1)}KB</p>
+          <a href={url} download="compressed.pdf" className="text-blue-600 underline">
+            Download
+          </a>
+          {after > 5 * 1024 * 1024 && <p className="text-sm">Try OCR</p>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function CompressPage() {
+  return (
+    <AppErrorBoundary>
+      <ToastProvider>
+        <Inner />
+      </ToastProvider>
+    </AppErrorBoundary>
+  );
+}

--- a/app/(ats)/ats-toolkit/jd-match/page.tsx
+++ b/app/(ats)/ats-toolkit/jd-match/page.tsx
@@ -1,0 +1,160 @@
+'use client';
+import AppErrorBoundary from '@/components/AppErrorBoundary';
+import { ToastProvider, useToast } from '@/components/toast/ToastProvider';
+import DropZone from '@/components/DropZone';
+import Seo from '@/components/Seo';
+import { extractATSSafeText } from '@/lib/ats/export';
+import { scoreResumeVsJD } from '@/lib/match/score';
+import { track } from '@/lib/analytics';
+import { createSampleJDText, createSampleResumePDF } from '@/lib/samples';
+import { useState } from 'react';
+
+function Inner() {
+  const toast = useToast();
+  const [jd, setJd] = useState(createSampleJDText());
+  const [resume, setResume] = useState('');
+  const [report, setReport] = useState<any>(null);
+
+  const handleResume = async (files: File[]) => {
+    const file = files[0];
+    if (!file) return;
+    track('file_dropped', { tool: 'jd-match' });
+    const txt = await extractATSSafeText(file);
+    setResume(txt);
+  };
+
+  const fetchJD = async (url: string) => {
+    try {
+      const res = await fetch(url);
+      const html = await res.text();
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      const main = doc.querySelector('main') || doc.body;
+      setJd(main?.textContent || '');
+    } catch {
+      toast({ message: 'Fetch failed', type: 'error' });
+    }
+  };
+
+  const score = () => {
+    track('jd_match_started');
+    const r = scoreResumeVsJD(resume, jd);
+    setReport(r);
+    track('jd_match_scored', { score: r.score0to100 });
+  };
+
+  const exportResume = async () => {
+    await navigator.clipboard.writeText(resume);
+    toast({ message: 'Resume text copied', type: 'success' });
+  };
+
+  const downloadMinimalPDF = async () => {
+    try {
+      const { PDFDocument, StandardFonts } = await import('pdf-lib');
+      const doc = await PDFDocument.create();
+      const page = doc.addPage();
+      const font = await doc.embedFont(StandardFonts.Helvetica);
+      const size = 12;
+      const lines = resume.split('\n');
+      lines.forEach((line, i) => page.drawText(line, { x: 40, y: page.getHeight() - 40 - i * (size + 4), size, font }));
+      const bytes = await doc.save();
+      const blob = new Blob([bytes], { type: 'application/pdf' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'resume.pdf';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      toast({ message: 'Install pdf-lib to enable PDF export', type: 'info' });
+    }
+  };
+
+  const trySampleResume = async () => {
+    const blob = await createSampleResumePDF();
+    handleResume([new File([blob], 'sample.pdf', { type: 'application/pdf' })]);
+  };
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <Seo title="JD Match" description="Score resume vs JD" />
+      <h2 className="text-xl font-semibold mb-4">JD Match</h2>
+      <textarea
+        className="w-full border p-2 rounded mb-2" rows={6}
+        value={jd}
+        onChange={(e) => setJd(e.target.value)}
+        aria-label="Job description"
+      />
+      <div className="flex mb-4 gap-2">
+        <input
+          type="url"
+          placeholder="JD URL"
+          className="flex-1 border p-2 rounded"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') fetchJD((e.target as HTMLInputElement).value);
+          }}
+          aria-label="JD URL"
+        />
+        <button className="border px-3 rounded" onClick={() => {
+          const input = (document.querySelector('input[type=url]') as HTMLInputElement);
+          fetchJD(input.value);
+        }}>Fetch JD</button>
+      </div>
+      <DropZone accept=".pdf,.docx,.txt,.md" onFiles={handleResume} />
+      <button className="mt-2 text-blue-600 underline" onClick={trySampleResume}>Try sample</button>
+      {resume && (
+        <div className="mt-4">
+          <button className="border px-3 py-1 rounded" onClick={score}>
+            Score
+          </button>
+        </div>
+      )}
+      {report && (
+        <div className="mt-4">
+          <svg width="200" height="100" viewBox="0 0 200 100">
+            <path d="M10 100 A90 90 0 0 1 190 100" stroke="#eee" strokeWidth="20" fill="none" />
+            <path d={`M10 100 A90 90 0 0 1 ${10 + 180 * (report.score0to100/100)} 100`} stroke="#4ade80" strokeWidth="20" fill="none" />
+            <text x="100" y="90" textAnchor="middle" fontSize="20">{report.score0to100}</text>
+          </svg>
+          <div className="flex gap-8">
+            <div>
+              <h4 className="font-semibold">Must-have missing</h4>
+              <ul className="list-disc pl-5">
+                {report.mustHaveMissing.map((m: string) => <li key={m}>{m}</li>)}
+              </ul>
+            </div>
+            <div>
+              <h4 className="font-semibold">Nice-to-have missing</h4>
+              <ul className="list-disc pl-5">
+                {report.niceToHaveMissing.map((m: string) => <li key={m}>{m}</li>)}
+              </ul>
+            </div>
+          </div>
+          <div className="mt-4">
+            <h4 className="font-semibold">Bullet suggestions</h4>
+            <ul className="list-disc pl-5">
+              {report.bulletSuggestions.map((b: string, i: number) => <li key={i}>{b}</li>)}
+            </ul>
+          </div>
+          <div className="mt-4 space-x-4">
+            <button onClick={exportResume} className="text-blue-600 underline">
+              Export ATS Text
+            </button>
+            <button onClick={downloadMinimalPDF} className="text-blue-600 underline">
+              Download Minimal PDF
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function JDMatchPage() {
+  return (
+    <AppErrorBoundary>
+      <ToastProvider>
+        <Inner />
+      </ToastProvider>
+    </AppErrorBoundary>
+  );
+}

--- a/app/(ats)/ats-toolkit/ocr/page.tsx
+++ b/app/(ats)/ats-toolkit/ocr/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+import AppErrorBoundary from '@/components/AppErrorBoundary';
+import { ToastProvider, useToast } from '@/components/toast/ToastProvider';
+import DropZone from '@/components/DropZone';
+import Seo from '@/components/Seo';
+import { track } from '@/lib/analytics';
+import { createSampleScanJPG } from '@/lib/samples';
+import { useState } from 'react';
+
+function Inner() {
+  const toast = useToast();
+  const [text, setText] = useState('');
+  const [confidence, setConfidence] = useState<number | null>(null);
+
+  const handle = async (files: File[]) => {
+    const file = files[0];
+    if (!file) return;
+    track('file_dropped', { tool: 'ocr' });
+    if (file.type === 'application/pdf') {
+      try {
+        const pdfjs = await import('pdfjs-dist/build/pdf');
+        const pdf = await pdfjs.getDocument({ data: await file.arrayBuffer() }).promise;
+        let full = '';
+        for (let i = 1; i <= pdf.numPages; i++) {
+          const page = await pdf.getPage(i);
+          const canvas = document.createElement('canvas');
+          const viewport = page.getViewport({ scale: 1.5 });
+          canvas.width = viewport.width;
+          canvas.height = viewport.height;
+          await page.render({ canvasContext: canvas.getContext('2d') as any, viewport }).promise;
+          const blob: Blob = await new Promise((res) => canvas.toBlob((b) => res(b || new Blob()), 'image/jpeg'));
+          const textChunk = await runOCR(blob);
+          full += textChunk.text + '\n';
+        }
+        setText(full);
+        setConfidence(null);
+      } catch {
+        toast({ message: 'PDF OCR unavailable', type: 'error' });
+      }
+    } else {
+      const res = await runOCR(file);
+      setText(res.text);
+      setConfidence(res.meanConfidence || null);
+    }
+    track('task_completed', { tool: 'ocr' });
+  };
+
+  async function runOCR(blob: Blob): Promise<{ text: string; meanConfidence?: number }> {
+    return await new Promise((resolve) => {
+      const worker = new Worker(new URL('../../../../src/workers/ocr.worker.ts', import.meta.url), { type: 'module' });
+      worker.onmessage = (e) => {
+        const data = e.data;
+        if (data.text) resolve({ text: data.text, meanConfidence: data.meanConfidence });
+        if (data.error) {
+          toast({ message: data.error, type: 'error' });
+          resolve({ text: data.error });
+        }
+      };
+      worker.postMessage({ blob });
+    });
+  }
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(text);
+    toast({ message: 'Copied', type: 'success' });
+  };
+
+  const trySample = async () => {
+    const jpg = await createSampleScanJPG();
+    handle([new File([jpg], 'scan.jpg', { type: 'image/jpeg' })]);
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <Seo title="OCR" description="Image to text" />
+      <h2 className="text-xl font-semibold mb-4">OCR</h2>
+      <DropZone accept=".pdf,.png,.jpg,.jpeg" onFiles={handle} />
+      <button className="mt-4 text-blue-600 underline" onClick={trySample}>
+        Try sample
+      </button>
+      {text && (
+        <div className="mt-4">
+          <pre className="whitespace-pre-wrap bg-gray-100 p-2 rounded max-h-96 overflow-auto">{text}</pre>
+          {confidence !== null && <p className="text-sm">Confidence: {confidence?.toFixed(1)}</p>}
+          <button onClick={copy} className="text-blue-600 underline mt-2">
+            Copy
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function OCRPage() {
+  return (
+    <AppErrorBoundary>
+      <ToastProvider>
+        <Inner />
+      </ToastProvider>
+    </AppErrorBoundary>
+  );
+}

--- a/app/(ats)/ats-toolkit/page.tsx
+++ b/app/(ats)/ats-toolkit/page.tsx
@@ -1,0 +1,37 @@
+import Hero from '@/components/Hero';
+import ToolCard from '@/components/ToolCard';
+import PrivacyFooter from '@/components/PrivacyFooter';
+import Seo from '@/components/Seo';
+import { ToastProvider } from '@/components/toast/ToastProvider';
+import AppErrorBoundary from '@/components/AppErrorBoundary';
+
+const tools = [
+  { title: 'Compress', href: '/ats-toolkit/compress', hint: 'Shrink PDF size' },
+  { title: 'ATS Export', href: '/ats-toolkit/ats-export', hint: 'Extract clean text' },
+  { title: 'OCR', href: '/ats-toolkit/ocr', hint: 'Image/PDF to text' },
+  { title: 'JD Match', href: '/ats-toolkit/jd-match', hint: 'Resume vs Job' },
+];
+
+export default function Page() {
+  return (
+    <AppErrorBoundary>
+      <ToastProvider>
+        <Seo title="ATS Toolkit" description="Tools for ATS friendly resumes" />
+        <Hero />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 px-4">
+          {tools.map((t) => (
+            <ToolCard key={t.href} {...t} />
+          ))}
+        </div>
+        <div className="mt-10 p-4 border rounded max-w-md mx-auto text-sm">
+          <h4 className="font-semibold mb-2">Enable full features</h4>
+          <p className="mb-1">Optional installs:</p>
+          <pre className="bg-gray-100 p-2 rounded text-xs">
+            npm install pdf-lib pdfjs-dist tesseract.js
+          </pre>
+        </div>
+        <PrivacyFooter />
+      </ToastProvider>
+    </AppErrorBoundary>
+  );
+}

--- a/public/README.txt
+++ b/public/README.txt
@@ -1,0 +1,1 @@
+Sample assets (resume PDF, scan JPG) are generated at runtime. No binary files are stored in the repo.

--- a/src/components/AppErrorBoundary.tsx
+++ b/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface State { hasError: boolean; }
+
+export default class AppErrorBoundary extends Component<{ children: ReactNode }, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 text-center" role="alert">
+          Something went wrong.{' '}
+          <button
+            className="text-blue-600 underline"
+            onClick={() => (this.setState({ hasError: false }), location.reload())}
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -1,0 +1,81 @@
+'use client';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface Props {
+  accept?: string;
+  onFiles: (files: File[]) => void;
+  onText?: (text: string) => void;
+}
+
+export default function DropZone({ accept, onFiles, onText }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [over, setOver] = useState(false);
+
+  const handleFiles = useCallback(
+    (files: FileList | null) => {
+      if (!files) return;
+      onFiles(Array.from(files));
+    },
+    [onFiles]
+  );
+
+  useEffect(() => {
+    const zone = ref.current;
+    if (!zone) return;
+    const prevent = (e: DragEvent) => {
+      e.preventDefault();
+      if (e.type === 'dragenter') setOver(true);
+      if (e.type === 'dragleave') setOver(false);
+    };
+    const drop = (e: DragEvent) => {
+      e.preventDefault();
+      setOver(false);
+      handleFiles(e.dataTransfer?.files || null);
+    };
+    zone.addEventListener('dragenter', prevent);
+    zone.addEventListener('dragover', prevent);
+    zone.addEventListener('dragleave', prevent);
+    zone.addEventListener('drop', drop);
+    return () => {
+      zone.removeEventListener('dragenter', prevent);
+      zone.removeEventListener('dragover', prevent);
+      zone.removeEventListener('dragleave', prevent);
+      zone.removeEventListener('drop', drop);
+    };
+  }, [handleFiles]);
+
+  useEffect(() => {
+    const paste = (e: ClipboardEvent) => {
+      const files = e.clipboardData?.files;
+      if (files && files.length) handleFiles(files);
+      const text = e.clipboardData?.getData('text');
+      if (text && onText) onText(text);
+    };
+    window.addEventListener('paste', paste);
+    return () => window.removeEventListener('paste', paste);
+  }, [handleFiles, onText]);
+
+  return (
+    <div
+      ref={ref}
+      tabIndex={0}
+      className={`border-2 border-dashed rounded p-10 text-center cursor-pointer focus:outline-none focus:ring ${
+        over ? 'bg-blue-50' : ''
+      }`}
+      onClick={() => {
+        const inp = document.createElement('input');
+        inp.type = 'file';
+        if (accept) inp.accept = accept;
+        inp.onchange = () => handleFiles(inp.files);
+        inp.click();
+      }}
+      role="button"
+      aria-label="Upload file"
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') (e.target as HTMLElement).click();
+      }}
+    >
+      Drop file here or click to upload
+    </div>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,14 @@
+
+export default function Hero() {
+  return (
+    <section className="text-center py-10" aria-label="ATS Toolkit hero">
+      <h1 className="text-3xl font-bold mb-4">ATS-ready CV Toolkit</h1>
+      <p className="mb-6">Upload → Pick tool → Download ATS output</p>
+      <div className="flex justify-center gap-4 text-sm">
+        <span>1. Upload</span>
+        <span>2. Pick tool</span>
+        <span>3. Download</span>
+      </div>
+    </section>
+  );
+}

--- a/src/components/PrivacyFooter.tsx
+++ b/src/components/PrivacyFooter.tsx
@@ -1,0 +1,7 @@
+export default function PrivacyFooter() {
+  return (
+    <footer className="text-center text-xs text-gray-500 mt-10" aria-label="privacy notice">
+      Private by default. Files auto-delete after 30 minutes. No training.
+    </footer>
+  );
+}

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,0 +1,15 @@
+import Head from 'next/head';
+
+interface Props {
+  title: string;
+  description: string;
+}
+
+export default function Seo({ title, description }: Props) {
+  return (
+    <Head>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+    </Head>
+  );
+}

--- a/src/components/ToolCard.tsx
+++ b/src/components/ToolCard.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { track } from '../lib/analytics';
+
+interface Props {
+  title: string;
+  href: string;
+  hint: string;
+}
+
+export default function ToolCard({ title, href, hint }: Props) {
+  return (
+    <Link
+      href={href}
+      className="border rounded p-4 focus:outline-none focus:ring block"
+      onClick={() => track('tool_opened', { tool: title })}
+      aria-label={`Start ${title}`}
+    >
+      <h3 className="font-semibold mb-2">{title}</h3>
+      <p className="text-sm mb-4">{hint}</p>
+      <span className="text-blue-600">Start →</span>
+    </Link>
+  );
+}

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { createContext, useContext, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export interface Toast {
+  id: number;
+  message: string;
+  type?: 'success' | 'error' | 'info';
+}
+
+const Ctx = createContext<(t: Omit<Toast, 'id'>) => void>(() => {});
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const add = (t: Omit<Toast, 'id'>) => {
+    const toast: Toast = { id: Date.now(), ...t };
+    setToasts((s) => [...s, toast]);
+    setTimeout(() =>
+      setToasts((s) => s.filter((x) => x.id !== toast.id)),
+    4000);
+  };
+
+  return (
+    <Ctx.Provider value={add}>
+      {children}
+      {createPortal(
+        <div className="fixed top-4 right-4 space-y-2 z-50">
+          {toasts.map((t) => (
+            <div
+              key={t.id}
+              className={`px-3 py-2 rounded shadow text-white ${
+                t.type === 'error'
+                  ? 'bg-red-600'
+                  : t.type === 'success'
+                  ? 'bg-green-600'
+                  : 'bg-gray-800'
+              }`}
+            >
+              {t.message}
+            </div>
+          ))}
+        </div>,
+        document.body
+      )}
+    </Ctx.Provider>
+  );
+}
+
+export const useToast = () => useContext(Ctx);

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,10 @@
+export function track(event: string, props?: Record<string, any>) {
+  try {
+    console.log('track', event, props);
+    if (typeof window !== 'undefined') {
+      (window as any).gtag?.('event', event, props);
+    }
+  } catch (err) {
+    console.warn('analytics error', err);
+  }
+}

--- a/src/lib/ats/export.ts
+++ b/src/lib/ats/export.ts
@@ -1,0 +1,74 @@
+export async function extractATSSafeText(input: File | ArrayBuffer | string): Promise<string> {
+  const normalize = (txt: string) =>
+    txt
+      .replace(/\r\n?/g, '\n')
+      .replace(/[\t\f]+/g, ' ')
+      .replace(/\n{2,}/g, '\n')
+      .trim();
+
+  if (typeof input === 'string') return normalize(input);
+
+  const name = (input as File).name || '';
+  const ext = name.split('.').pop()?.toLowerCase();
+
+  async function readAsText(file: File): Promise<string> {
+    return new Promise((res, rej) => {
+      const fr = new FileReader();
+      fr.onerror = () => rej(fr.error);
+      fr.onload = () => res(fr.result as string);
+      fr.readAsText(file);
+    });
+  }
+
+  async function readAsArrayBuffer(file: File): Promise<ArrayBuffer> {
+    return new Promise((res, rej) => {
+      const fr = new FileReader();
+      fr.onerror = () => rej(fr.error);
+      fr.onload = () => res(fr.result as ArrayBuffer);
+      fr.readAsArrayBuffer(file);
+    });
+  }
+
+  try {
+    if (ext === 'txt' || ext === 'md') {
+      const text = await readAsText(input as File);
+      return normalize(text);
+    }
+    if (ext === 'docx') {
+      const buf = await readAsArrayBuffer(input as File);
+      try {
+        const decoder = new TextDecoder();
+        return normalize(decoder.decode(buf));
+      } catch {
+        return 'DOCX parsing unavailable; install a docx parser.';
+      }
+    }
+    if (ext === 'pdf' || input instanceof ArrayBuffer) {
+      const data = input instanceof ArrayBuffer ? input : await readAsArrayBuffer(input as File);
+      try {
+        const pdfjs = await import('pdfjs-dist/build/pdf');
+        const pdf = await pdfjs.getDocument({ data }).promise;
+        let out = '';
+        for (let i = 1; i <= pdf.numPages; i++) {
+          const page = await pdf.getPage(i);
+          const txt = await page.getTextContent();
+          out +=
+            txt.items
+              .map((it: any) => ('str' in it ? (it.str as string) : ''))
+              .join(' ') + '\n';
+        }
+        const result = normalize(out);
+        return result || 'No extractable text—try OCR.';
+      } catch {
+        return 'No extractable text—try OCR.';
+      }
+    }
+    if (input instanceof ArrayBuffer) {
+      const decoder = new TextDecoder();
+      return normalize(decoder.decode(input));
+    }
+    return 'Unsupported file type.';
+  } catch (err: any) {
+    return `Error: ${err.message || err}`;
+  }
+}

--- a/src/lib/match/score.ts
+++ b/src/lib/match/score.ts
@@ -1,0 +1,75 @@
+export type MatchReport = {
+  score0to100: number;
+  mustHaveMissing: string[];
+  niceToHaveMissing: string[];
+  bulletSuggestions: string[];
+};
+
+const STOPWORDS = new Set('the a an and or of to in with on for by'.split(' '));
+const SYNONYMS: Record<string, string[]> = {
+  excel: ['ms excel'],
+  bachelor's: ['ba', 'bs', 'bsc'],
+  crm: ['salesforce', 'hubspot'],
+  python: ['py'],
+};
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t && !STOPWORDS.has(t));
+}
+
+function expand(tokens: string[]): Set<string> {
+  const set = new Set(tokens);
+  for (const t of tokens) {
+    for (const [key, syns] of Object.entries(SYNONYMS)) {
+      if (t === key || syns.includes(t)) {
+        set.add(key);
+        syns.forEach((s) => set.add(s));
+      }
+    }
+  }
+  return set;
+}
+
+export function scoreResumeVsJD(resumeText: string, jdText: string): MatchReport {
+  const resumeTokens = expand(tokenize(resumeText));
+  const jdTokens = expand(tokenize(jdText));
+  const mustHaveMissing: string[] = [];
+  const niceToHaveMissing: string[] = [];
+
+  jdTokens.forEach((t) => {
+    if (!resumeTokens.has(t)) {
+      if (['must', 'required'].includes(t)) return;
+      if (['nice', 'plus', 'preferred'].includes(t)) return;
+      if (resumeTokens.size === 0) return;
+      // naive: treat first half as must, rest as nice
+    }
+  });
+
+  const intersection = new Set([...jdTokens].filter((t) => resumeTokens.has(t)));
+  const keywordScore = jdTokens.size ? (intersection.size / jdTokens.size) * 40 : 0;
+  const synonymScore = intersection.size * 2; // crude
+  const experienceScore = resumeText.includes('experience') ? 20 : 0;
+  const educationScore = /bachelor|degree|cert/i.test(resumeText) ? 10 : 0;
+  const formatScore = /\n- /.test(resumeText) ? 10 : 0;
+
+  const total = Math.min(
+    100,
+    Math.round(keywordScore + synonymScore + experienceScore + educationScore + formatScore)
+  );
+
+  const missing = [...jdTokens].filter((t) => !resumeTokens.has(t));
+  missing.slice(0, 5).forEach((m, i) => {
+    if (i < 3) mustHaveMissing.push(m);
+    else niceToHaveMissing.push(m);
+  });
+
+  const bulletSuggestions = missing.slice(0, 3).map(
+    (m) => `Improved ${m} by 10% using data-driven methods`
+  );
+
+  return { score0to100: total, mustHaveMissing, niceToHaveMissing, bulletSuggestions };
+}

--- a/src/lib/quota.ts
+++ b/src/lib/quota.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const DAY = 24 * 60 * 60 * 1000;
+const KEY = 'ats-quota';
+const FREE_LIMIT = 5;
+const FREE_BYTES = 5 * 1024 * 1024;
+
+interface QuotaState {
+  date: string;
+  count: number;
+  bytes: number;
+}
+
+function loadState(): QuotaState {
+  if (typeof window === 'undefined') return { date: '', count: 0, bytes: 0 };
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return { date: '', count: 0, bytes: 0 };
+    return JSON.parse(raw) as QuotaState;
+  } catch {
+    return { date: '', count: 0, bytes: 0 };
+  }
+}
+
+export function useQuota() {
+  const [state, setState] = useState<QuotaState>(() => {
+    const s = loadState();
+    if (!s.date || Date.now() - new Date(s.date).getTime() > DAY) {
+      return { date: new Date().toISOString(), count: 0, bytes: 0 };
+    }
+    return s;
+  });
+  const isPro = useRef(false); // stub for future
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(KEY, JSON.stringify(state));
+    }
+  }, [state]);
+
+  const allowed = useCallback(
+    (fileSize = 0) => {
+      if (isPro.current) return true;
+      if (state.count >= FREE_LIMIT) return false;
+      if (state.bytes + fileSize > FREE_BYTES) return false;
+      return true;
+    },
+    [state]
+  );
+
+  const consume = useCallback(
+    (fileSize = 0) => {
+      setState((s) => ({
+        date: s.date,
+        count: s.count + 1,
+        bytes: s.bytes + fileSize,
+      }));
+    },
+    []
+  );
+
+  return { allowed, consume, state };
+}

--- a/src/lib/samples.ts
+++ b/src/lib/samples.ts
@@ -1,0 +1,50 @@
+export function createSampleJDText(): string {
+  return `We seek a Software Engineer with experience in React, TypeScript, and cloud deployments.
+Must know AWS and CI/CD. Nice to have: Docker, Python.`;
+}
+
+export function createSampleResumeText(): string {
+  return `Jane Doe\nExperience\n- Built React apps improving conversion by 20%\n- Managed AWS infrastructure\nSkills: TypeScript, Docker, Python`; 
+}
+
+export async function createSampleResumePDF(): Promise<Blob> {
+  const text = createSampleResumeText();
+  try {
+    const { PDFDocument, StandardFonts } = await import('pdf-lib');
+    const doc = await PDFDocument.create();
+    const page = doc.addPage();
+    const font = await doc.embedFont(StandardFonts.Helvetica);
+    const size = 12;
+    const lines = text.split('\n');
+    lines.forEach((line, i) => {
+      page.drawText(line, { x: 40, y: page.getHeight() - 40 - i * (size + 4), size, font });
+    });
+    const bytes = await doc.save();
+    return new Blob([bytes], { type: 'application/pdf' });
+  } catch {
+    return new Blob([text], { type: 'text/plain' });
+  }
+}
+
+export async function createSampleScanJPG(): Promise<Blob> {
+  const text = 'Sample Scan Text';
+  const canvas = typeof OffscreenCanvas !== 'undefined'
+    ? new OffscreenCanvas(400, 200)
+    : document.createElement('canvas');
+  canvas.width = 400;
+  canvas.height = 200;
+  const ctx = (canvas as any).getContext('2d');
+  ctx.fillStyle = '#fff';
+  ctx.fillRect(0, 0, 400, 200);
+  ctx.fillStyle = '#000';
+  ctx.font = '20px sans-serif';
+  ctx.fillText(text, 10, 100);
+  const blob: Blob = await new Promise((res) => {
+    (canvas as HTMLCanvasElement).toBlob((b) => res(b || new Blob()), 'image/jpeg', 0.9);
+  });
+  return blob;
+}
+
+export function blobUrl(blob: Blob): string {
+  return URL.createObjectURL(blob);
+}

--- a/src/workers/compress.worker.ts
+++ b/src/workers/compress.worker.ts
@@ -1,0 +1,30 @@
+/// <reference lib="webworker" />
+
+self.onmessage = async (e: MessageEvent) => {
+  const { pdfBytes, dpi = 120, quality = 0.7 } = e.data || {};
+  try {
+    const pdfjs = await import('pdfjs-dist/build/pdf');
+    const pdfLib = await import('pdf-lib');
+    const doc = await pdfjs.getDocument({ data: pdfBytes }).promise;
+    const pdfDoc = await pdfLib.PDFDocument.create();
+    let beforeSize = pdfBytes.byteLength;
+    let afterSize = 0;
+    for (let i = 1; i <= doc.numPages; i++) {
+      const page = await doc.getPage(i);
+      const viewport = page.getViewport({ scale: dpi / 72 });
+      const canvas = new OffscreenCanvas(viewport.width, viewport.height);
+      await page.render({ canvasContext: canvas.getContext('2d') as any, viewport }).promise;
+      const blob: Blob = await canvas.convertToBlob({ type: 'image/jpeg', quality });
+      const imgBytes = await blob.arrayBuffer();
+      const img = await pdfDoc.embedJpg(imgBytes);
+      const p = pdfDoc.addPage([viewport.width, viewport.height]);
+      p.drawImage(img, { x: 0, y: 0, width: viewport.width, height: viewport.height });
+      postMessage({ progress: i / doc.numPages });
+    }
+    const outBytes = await pdfDoc.save();
+    afterSize = outBytes.byteLength;
+    postMessage({ bytes: outBytes, beforeSize, afterSize, progress: 1 });
+  } catch (err) {
+    postMessage({ error: 'compression unavailable', details: String(err) });
+  }
+};

--- a/src/workers/ocr.worker.ts
+++ b/src/workers/ocr.worker.ts
@@ -1,0 +1,17 @@
+/// <reference lib="webworker" />
+
+self.onmessage = async (e: MessageEvent) => {
+  const { blob } = e.data || {};
+  try {
+    const { createWorker } = await import('tesseract.js');
+    const worker = await createWorker('eng');
+    await worker.setParameters({ preserve_interword_spaces: '1' });
+    const { data } = await worker.recognize(blob, undefined, {
+      progress: (p: any) => postMessage({ progress: p.progress, textChunk: p.status }),
+    });
+    await worker.terminate();
+    postMessage({ text: data.text, meanConfidence: data.confidence });
+  } catch (err) {
+    postMessage({ error: 'OCR unavailable', details: String(err) });
+  }
+};


### PR DESCRIPTION
## Summary
- add landing and tool pages for Compress, ATS Export, OCR, and JD Match
- implement DropZone, toast system, privacy footer, and error boundary
- add text extraction, matching score, sample generators, and web workers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c41af1f98832f82207c71eb382f79