### PR TITLE
Fix module resolution and build for ATS toolkit pages

### DIFF
--- a/app/(ats)/ats-toolkit/ocr/page.tsx
+++ b/app/(ats)/ats-toolkit/ocr/page.tsx
@@ -18,7 +18,7 @@ function Inner() {
     track('file_dropped', { tool: 'ocr' });
     if (file.type === 'application/pdf') {
       try {
-        const pdfjs = await import('pdfjs-dist/build/pdf');
+        const pdfjs = await import('pdfjs-dist');
         const pdf = await pdfjs.getDocument({ data: await file.arrayBuffer() }).promise;
         let full = '';
         for (let i = 1; i <= pdf.numPages; i++) {

--- a/src/components/ToolCard.tsx
+++ b/src/components/ToolCard.tsx
@@ -1,3 +1,4 @@
+'use client';
 import Link from 'next/link';
 import { track } from '../lib/analytics';
 

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -23,26 +23,27 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   return (
     <Ctx.Provider value={add}>
       {children}
-      {createPortal(
-        <div className="fixed top-4 right-4 space-y-2 z-50">
-          {toasts.map((t) => (
-            <div
-              key={t.id}
-              className={`px-3 py-2 rounded shadow text-white ${
-                t.type === 'error'
-                  ? 'bg-red-600'
-                  : t.type === 'success'
-                  ? 'bg-green-600'
-                  : 'bg-gray-800'
-              }`}
-            >
-              {t.message}
-            </div>
-          ))}
-        </div>,
-        document.body
-      )}
-    </Ctx.Provider>
+      {typeof document !== 'undefined' &&
+        createPortal(
+          <div className="fixed top-4 right-4 space-y-2 z-50">
+            {toasts.map((t) => (
+              <div
+                key={t.id}
+                className={`px-3 py-2 rounded shadow text-white ${
+                  t.type === 'error'
+                    ? 'bg-red-600'
+                    : t.type === 'success'
+                    ? 'bg-green-600'
+                    : 'bg-gray-800'
+                }`}
+              >
+                {t.message}
+              </div>
+            ))}
+          </div>,
+          document.body
+        )}
+      </Ctx.Provider>
   );
 }
 

--- a/src/lib/ats/export.ts
+++ b/src/lib/ats/export.ts
@@ -46,7 +46,7 @@ export async function extractATSSafeText(input: File | ArrayBuffer | string): Pr
     if (ext === 'pdf' || input instanceof ArrayBuffer) {
       const data = input instanceof ArrayBuffer ? input : await readAsArrayBuffer(input as File);
       try {
-        const pdfjs = await import('pdfjs-dist/build/pdf');
+        const pdfjs = await import('pdfjs-dist');
         const pdf = await pdfjs.getDocument({ data }).promise;
         let out = '';
         for (let i = 1; i <= pdf.numPages; i++) {

--- a/src/lib/match/score.ts
+++ b/src/lib/match/score.ts
@@ -8,7 +8,7 @@ export type MatchReport = {
 const STOPWORDS = new Set('the a an and or of to in with on for by'.split(' '));
 const SYNONYMS: Record<string, string[]> = {
   excel: ['ms excel'],
-  bachelor's: ['ba', 'bs', 'bsc'],
+  "bachelor's": ['ba', 'bs', 'bsc'],
   crm: ['salesforce', 'hubspot'],
   python: ['py'],
 };

--- a/src/workers/compress.worker.ts
+++ b/src/workers/compress.worker.ts
@@ -3,7 +3,7 @@
 self.onmessage = async (e: MessageEvent) => {
   const { pdfBytes, dpi = 120, quality = 0.7 } = e.data || {};
   try {
-    const pdfjs = await import('pdfjs-dist/build/pdf');
+    const pdfjs = await import('pdfjs-dist');
     const pdfLib = await import('pdf-lib');
     const doc = await pdfjs.getDocument({ data: pdfBytes }).promise;
     const pdfDoc = await pdfLib.PDFDocument.create();

--- a/src/workers/ocr.worker.ts
+++ b/src/workers/ocr.worker.ts
@@ -4,7 +4,7 @@ self.onmessage = async (e: MessageEvent) => {
   const { blob } = e.data || {};
   try {
     const { createWorker } = await import('tesseract.js');
-    const worker = await createWorker('eng');
+    const worker = await (createWorker as any)('eng');
     await worker.setParameters({ preserve_interword_spaces: '1' });
     const { data } = await worker.recognize(blob, undefined, {
       progress: (p: any) => postMessage({ progress: p.progress, textChunk: p.status }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "lib": ["dom", "dom.iterable", "esnext", "webworker"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext",
+      "webworker"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -13,8 +18,26 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "src/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- resolve '@/...' paths by adding TypeScript baseUrl and alias to src directory
- replace deprecated pdfjs-dist build imports and correct worker typings
- mark client-only components and guard ToastProvider from server document access

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c46e5f9c8832faff9af6fba724f09