### PR TITLE
feat: add global header and footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import '../styles/globals.css';
 import React from 'react';
 import AppErrorBoundary from '@/components/AppErrorBoundary';
+import Header from '@/components/layout/Header';
+import Footer from '@/components/layout/Footer';
 
 export const metadata = {
   title: 'PDF Tool Site',
@@ -13,9 +15,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <link rel="manifest" href="/manifest.webmanifest" />
       </head>
-      <body className="min-h-screen bg-gray-50 text-gray-900">
+      <body className="min-h-screen bg-gray-50 text-gray-900 flex flex-col">
         <AppErrorBoundary>
-          {children}
+          <>
+            <Header />
+            <main className="flex-1">{children}</main>
+            <Footer />
+          </>
         </AppErrorBoundary>
         <script
           dangerouslySetInnerHTML={{

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="40" viewBox="0 0 150 40" fill="none">
+  <text x="0" y="28" font-family="sans-serif" font-size="28" fill="#2563eb">NoUploadPDF</text>
+</svg>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+
+export default function Footer() {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="bg-gray-900 text-white py-8 px-4 mt-10">
+      <div className="max-w-7xl mx-auto space-y-8">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <div>
+            <h2 className="text-lg font-semibold mb-2">About</h2>
+            <p className="text-sm text-gray-400">
+              NoUploadPDF is a secure online tool for converting and processing files without storing them on our servers.
+            </p>
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold mb-2">Quick Links</h2>
+            <ul className="space-y-1">
+              <li>
+                <Link href="/" className="hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  Home
+                </Link>
+              </li>
+              <li>
+                <Link href="/tools/merge" className="hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  All Tools
+                </Link>
+              </li>
+              <li>
+                <Link href="/privacy" className="hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  Privacy Policy
+                </Link>
+              </li>
+              <li>
+                <Link href="/terms" className="hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  Terms of Service
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold mb-2">Contact</h2>
+            <p className="text-sm">
+              <a
+                href="mailto:support@nouploadpdf.com"
+                className="hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                support@nouploadpdf.com
+              </a>
+            </p>
+          </div>
+        </div>
+        <p className="text-sm text-gray-400">
+          All files are processed securely and deleted automatically after completion.
+        </p>
+        <div className="border-t border-gray-700 pt-4 text-sm text-gray-400 text-center">
+          © {year} NoUploadPDF — All rights reserved.
+        </div>
+      </div>
+    </footer>
+  );
+}
+

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,132 @@
+'use client';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+const navLinks = [
+  { href: '/', label: 'Home' },
+  { href: '/tools/merge', label: 'All Tools' },
+  { href: '/privacy', label: 'Privacy' },
+  { href: '/support', label: 'Support' },
+];
+
+export default function Header() {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [secure, setSecure] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.isSecureContext) {
+      setSecure(true);
+    }
+  }, []);
+
+  return (
+    <header className="sticky top-0 z-50 bg-white shadow-sm">
+      <div className="max-w-7xl mx-auto flex items-center justify-between py-3 px-4">
+        <Link href="/" className="flex items-center focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <img src="/logo.svg" alt="NoUploadPDF logo" className="h-8 w-auto" />
+        </Link>
+        <nav className="hidden md:flex space-x-6" aria-label="Primary Navigation">
+          {navLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="text-gray-700 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="flex items-center gap-4">
+          {secure && (
+            <span className="hidden md:flex items-center text-xs text-gray-500">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                className="h-4 w-4 mr-1"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M16 11V7a4 4 0 00-8 0v4M5 11h14v10H5V11z"
+                />
+              </svg>
+              HTTPS Secured
+            </span>
+          )}
+          <Link
+            href="/tools/merge"
+            className="hidden md:inline-block bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            Upload File
+          </Link>
+          <button
+            className="md:hidden focus:outline-none focus:ring-2 focus:ring-blue-500"
+            aria-label="Toggle menu"
+            aria-expanded={menuOpen}
+            aria-controls="mobile-menu"
+            onClick={() => setMenuOpen((v) => !v)}
+          >
+            <svg
+              className="h-6 w-6 text-gray-800"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d={menuOpen ? 'M6 18L18 6M6 6l12 12' : 'M4 6h16M4 12h16M4 18h16'}
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div
+        id="mobile-menu"
+        className={`md:hidden overflow-hidden transition-[max-height] duration-300 bg-white ${menuOpen ? 'max-h-96 shadow-md' : 'max-h-0'}`}
+      >
+        <nav className="flex flex-col px-4 pb-4 space-y-2" aria-label="Mobile Navigation">
+          {navLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="block py-2 text-gray-700 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {link.label}
+            </Link>
+          ))}
+          <Link
+            href="/tools/merge"
+            className="mt-2 text-center bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            Upload File
+          </Link>
+          {secure && (
+            <span className="mt-2 flex items-center text-xs text-gray-500">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                className="h-4 w-4 mr-1"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M16 11V7a4 4 0 00-8 0v4M5 11h14v10H5V11z"
+                />
+              </svg>
+              HTTPS Secured
+            </span>
+          )}
+        </nav>
+      </div>
+    </header>
+  );
+}
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@ module.exports = {
   content: [
     "./pages/**/*.{js,jsx,ts,tsx}",
     "./components/**/*.{js,jsx,ts,tsx}",
+    "./src/**/*.{js,jsx,ts,tsx}",
     "./app/**/*.{js,jsx,ts,tsx}"
   ],
   theme: {


### PR DESCRIPTION
## Summary
- add responsive global header with navigation, secure context indicator, and upload CTA
- add site-wide footer with about, quick links, contact info, and security note
- wire header and footer into root layout and expand Tailwind scan paths

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d72f7a230832f8b64dcf99f93316d