### PR TITLE
feat: add privacy and terms pages

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+import { siteConfig } from "@/config/site";
+
+export const generateMetadata = (): Metadata => {
+  const title = `Privacy Policy | ${siteConfig.name}`;
+  const description = "How we protect your data and how the service handles uploaded files.";
+  const url = `${siteConfig.url}/privacy`;
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      images: [{ url: siteConfig.ogImage }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [siteConfig.ogImage],
+    },
+  };
+};
+
+export default function PrivacyPage() {
+  const year = new Date().getFullYear();
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-10 space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold">Privacy Policy</h1>
+        <p className="text-sm text-gray-500">Last updated {year}</p>
+      </header>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Overview</h2>
+        <p>
+          {siteConfig.name} converts and processes your files securely over HTTPS.
+          Files are handled in memory or temporary storage only for the purpose of
+          conversion.
+        </p>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Data We Process</h2>
+        <p>
+          Uploaded files are used solely for the requested operation and are
+          automatically deleted after processing. They are never stored long term
+          or used for model training. We keep minimal operational logs containing
+          error codes and timestamps but no file contents.
+        </p>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Cookies</h2>
+        <p>
+          We only use essential cookies needed for the site to function unless
+          you explicitly opt-in to analytics.
+        </p>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Security</h2>
+        <p>
+          All connections use HTTPS and access is restricted to authorized
+          systems. We do not share your files with third parties except trusted
+          infrastructure providers that help deliver the service.
+        </p>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Retention</h2>
+        <p>
+          Temporary files are removed automatically after processing is complete,
+          and operational logs are kept only as long as necessary to ensure the
+          service runs smoothly.
+        </p>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Your Rights</h2>
+        <p>
+          If you have questions about your data or want it removed from our
+          logs, please contact us and we will assist you.
+        </p>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Contact</h2>
+        <p>
+          Reach us at <a className="text-blue-600 underline focus:outline-none focus:ring-2 focus:ring-blue-500" href={`mailto:${siteConfig.email}`}>{siteConfig.email}</a>.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+import { siteConfig } from "@/config/site";
+
+export const generateMetadata = (): Metadata => {
+  const title = `Terms of Service | ${siteConfig.name}`;
+  const description = "The rules you agree to when using our tools.";
+  const url = `${siteConfig.url}/terms`;
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      images: [{ url: siteConfig.ogImage }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [siteConfig.ogImage],
+    },
+  };
+};
+
+export default function TermsPage() {
+  const year = new Date().getFullYear();
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-10 space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold">Terms of Service</h1>
+        <p className="text-sm text-gray-500">Last updated {year}</p>
+      </header>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Acceptable Use</h2>
+        <p>
+          You must have the rights to any content you upload and agree not to use
+          the service for illegal purposes, malware distribution, or abusive
+          automation.
+        </p>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Availability</h2>
+        <p>
+          We aim for high availability but do not guarantee uninterrupted access
+          and may change or discontinue features at any time.
+        </p>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Disclaimer</h2>
+        <p>
+          The service is provided on an "as is" basis without warranties of any
+          kind. Processing results may vary and we do not promise that the tools
+          will meet your requirements.
+        </p>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Limitation of Liability</h2>
+        <p>
+          To the maximum extent permitted by law, {siteConfig.name} and its
+          providers are not liable for any damages arising from the use of the
+          service.
+        </p>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Changes</h2>
+        <p>
+          We may update these terms from time to time. Continued use of the
+          service after changes means you accept the revised terms.
+        </p>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Contact</h2>
+        <p>
+          Questions about these terms? Email us at <a className="text-blue-600 underline focus:outline-none focus:ring-2 focus:ring-blue-500" href={`mailto:${siteConfig.email}`}>{siteConfig.email}</a>.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,8 @@
+export const siteConfig = {
+  name: "NoUploadPDF",
+  url: "https://nouploadpdf.com",
+  email: "support@nouploadpdf.com",
+  description:
+    "Convert and process files securely over HTTPS. We never store your files; they are auto-deleted after completion.",
+  ogImage: "/og/default.png"
+};


### PR DESCRIPTION
## Summary
- add shared site config with brand metadata
- create Privacy Policy and Terms of Service pages with metadata

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da0d67938832fafb1db4f0e1aeae4