### PR TITLE
feat: generate icons and og images via code

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,0 +1,29 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#111827",
+          borderRadius: 24,
+          color: "white",
+          fontSize: 96,
+          fontWeight: 800,
+          fontFamily: "Inter, Arial, sans-serif",
+        }}
+      >
+        N
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,0 +1,30 @@
+import { ImageResponse } from "next/og";
+import { siteConfig } from "@/config/site";
+
+export const size = { width: 64, height: 64 };
+export const contentType = "image/png";
+
+export default async function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#2563eb",
+          borderRadius: 12,
+          color: "white",
+          fontSize: 42,
+          fontWeight: 700,
+          fontFamily: "Inter, Arial, sans-serif",
+        }}
+      >
+        {siteConfig.name?.[0] ?? "N"}
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <head>
+        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="manifest" href="/manifest.webmanifest" />
       </head>
       <body className="min-h-screen bg-gray-50 text-gray-900 flex flex-col">

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,16 @@
+import { siteConfig } from "@/config/site";
+export default function manifest() {
+  return {
+    name: siteConfig.name,
+    short_name: siteConfig.name,
+    description: siteConfig.description,
+    start_url: "/",
+    display: "standalone",
+    background_color: "#ffffff",
+    theme_color: "#2563eb",
+    icons: [
+      { src: "/icon", sizes: "64x64", type: "image/png" },
+      { src: "/apple-icon", sizes: "180x180", type: "image/png", purpose: "any" }
+    ]
+  };
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,33 @@
+import { ImageResponse } from "next/og";
+import { siteConfig } from "@/config/site";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+function Frame({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        background: "linear-gradient(135deg,#0f172a 0%,#1e293b 100%)",
+        color: "white",
+        padding: 64,
+        justifyContent: "space-between",
+      }}
+    >
+      <div style={{ fontSize: 28, opacity: 0.8 }}>{siteConfig.name}</div>
+      <div style={{ fontSize: 70, fontWeight: 800, lineHeight: 1.05 }}>{title}</div>
+      <div style={{ fontSize: 30, opacity: 0.9 }}>{subtitle}</div>
+    </div>
+  );
+}
+
+export default function OG() {
+  return new ImageResponse(
+    <Frame title="Secure file tools" subtitle="No storage • HTTPS • Auto-delete" />,
+    { ...size }
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -13,13 +13,13 @@ export const generateMetadata = (): Metadata => {
       title,
       description,
       url,
-      images: [{ url: siteConfig.ogImage }],
+      images: [{ url: "/opengraph-image" }],
     },
     twitter: {
       card: "summary_large_image",
       title,
       description,
-      images: [siteConfig.ogImage],
+      images: ["/opengraph-image"],
     },
   };
 };

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -13,13 +13,13 @@ export const generateMetadata = (): Metadata => {
       title,
       description,
       url,
-      images: [{ url: siteConfig.ogImage }],
+      images: [{ url: "/opengraph-image" }],
     },
     twitter: {
       card: "summary_large_image",
       title,
       description,
-      images: [siteConfig.ogImage],
+      images: ["/opengraph-image"],
     },
   };
 };

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,0 +1,33 @@
+import { ImageResponse } from "next/og";
+import { siteConfig } from "@/config/site";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+function Frame({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        background: "linear-gradient(135deg,#0f172a 0%,#1e293b 100%)",
+        color: "white",
+        padding: 64,
+        justifyContent: "space-between",
+      }}
+    >
+      <div style={{ fontSize: 28, opacity: 0.8 }}>{siteConfig.name}</div>
+      <div style={{ fontSize: 70, fontWeight: 800, lineHeight: 1.05 }}>{title}</div>
+      <div style={{ fontSize: 30, opacity: 0.9 }}>{subtitle}</div>
+    </div>
+  );
+}
+
+export default function OG() {
+  return new ImageResponse(
+    <Frame title="Secure file tools" subtitle="No storage • HTTPS • Auto-delete" />,
+    { ...size }
+  );
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#2563eb" />
+  <text x="50" y="70" font-size="80" text-anchor="middle" fill="white" font-family="Arial, sans-serif">N</text>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,9 +1,0 @@
-{
-  "name": "PDF Tool Site",
-  "short_name": "PDFTools",
-  "start_url": "/",
-  "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#2563eb",
-  "icons": []
-}


### PR DESCRIPTION
## Summary
- generate favicon, app icons, and Open Graph images at runtime
- add manifest route and update pages to use generated OG image
- remove static manifest and favicon assets

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: next not found; dependency install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689dd63ed448832fbd399728e6f80bb8