### PR TITLE
fix metadata image imports for build

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,4 +1,4 @@
-import { ImageResponse } from "next/og";
+import { ImageResponse } from "next/server";
 
 export const size = { width: 180, height: 180 };
 export const contentType = "image/png";

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,4 +1,4 @@
-import { ImageResponse } from "next/og";
+import { ImageResponse } from "next/server";
 import { siteConfig } from "@/config/site";
 
 export const size = { width: 64, height: 64 };

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,4 +1,4 @@
-import { ImageResponse } from "next/og";
+import { ImageResponse } from "next/server";
 import { siteConfig } from "@/config/site";
 
 export const size = { width: 1200, height: 630 };

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,4 +1,4 @@
-import { ImageResponse } from "next/og";
+import { ImageResponse } from "next/server";
 import { siteConfig } from "@/config/site";
 
 export const size = { width: 1200, height: 630 };


### PR DESCRIPTION
## Summary
- import `ImageResponse` from `next/server` for icons and social images

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf25800c832fadae070532841d41