### PR TITLE
feat: migrate to strict typescript

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'import'],
+  extends: ['next/core-web-vitals', 'plugin:@typescript-eslint/recommended'],
+  rules: {
+    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        alphabetize: { order: 'asc', caseInsensitive: true },
+      },
+    ],
+  },
+};
+

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true
+}
+

--- a/app/(ats)/ats-toolkit/ats-export/page.tsx
+++ b/app/(ats)/ats-toolkit/ats-export/page.tsx
@@ -1,8 +1,9 @@
 import AppErrorBoundary from '@/components/AppErrorBoundary';
 import { ToastProvider } from '@/components/toast/ToastProvider';
 import ATSExportClient from './Client';
+import type { Metadata } from 'next';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'ATS Export',
   description: 'Extract text',
 };

--- a/app/(ats)/ats-toolkit/compress/page.tsx
+++ b/app/(ats)/ats-toolkit/compress/page.tsx
@@ -1,8 +1,9 @@
 import AppErrorBoundary from '@/components/AppErrorBoundary';
 import { ToastProvider } from '@/components/toast/ToastProvider';
 import CompressClient from './Client';
+import type { Metadata } from 'next';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'Compress',
   description: 'Shrink PDF size',
 };

--- a/app/(ats)/ats-toolkit/jd-match/page.tsx
+++ b/app/(ats)/ats-toolkit/jd-match/page.tsx
@@ -1,8 +1,9 @@
 import AppErrorBoundary from '@/components/AppErrorBoundary';
 import { ToastProvider } from '@/components/toast/ToastProvider';
 import JDMatchClient from './Client';
+import type { Metadata } from 'next';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'JD Match',
   description: 'Score resume vs JD',
 };

--- a/app/(ats)/ats-toolkit/ocr/page.tsx
+++ b/app/(ats)/ats-toolkit/ocr/page.tsx
@@ -1,8 +1,9 @@
 import AppErrorBoundary from '@/components/AppErrorBoundary';
 import { ToastProvider } from '@/components/toast/ToastProvider';
 import OCRClient from './Client';
+import type { Metadata } from 'next';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'OCR',
   description: 'Image to text',
 };

--- a/app/(ats)/ats-toolkit/page.tsx
+++ b/app/(ats)/ats-toolkit/page.tsx
@@ -3,6 +3,7 @@ import ToolCard from '@/components/ToolCard';
 import PrivacyFooter from '@/components/PrivacyFooter';
 import { ToastProvider } from '@/components/toast/ToastProvider';
 import AppErrorBoundary from '@/components/AppErrorBoundary';
+import type { Metadata } from 'next';
 
 const tools = [
   { title: 'Compress', href: '/ats-toolkit/compress', hint: 'Shrink PDF size' },
@@ -11,7 +12,7 @@ const tools = [
   { title: 'JD Match', href: '/ats-toolkit/jd-match', hint: 'Resume vs Job' },
 ];
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'ATS Toolkit',
   description: 'Tools for ATS friendly resumes',
 };

--- a/app/api/ai/jd-match/route.ts
+++ b/app/api/ai/jd-match/route.ts
@@ -1,13 +1,28 @@
 import { NextResponse } from 'next/server';
 
+interface MatchRequest {
+  resumeText: string;
+  jobDescription: string;
+}
+
+interface MatchSuccess {
+  score: number;
+  missingKeywords: string[];
+  improvedBullets: string[];
+}
+
+interface MatchError {
+  error: string;
+}
+
 export async function POST(req: Request) {
-  const { resumeText, jobDescription } = await req.json();
+  const { resumeText, jobDescription } = (await req.json()) as MatchRequest;
   if (!resumeText || !jobDescription) {
-    return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+    return NextResponse.json<MatchError>({ error: 'Missing fields' }, { status: 400 });
   }
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
-    return NextResponse.json({ error: 'Missing API key' }, { status: 500 });
+    return NextResponse.json<MatchError>({ error: 'Missing API key' }, { status: 500 });
   }
   const prompt = `Resume:\n${resumeText}\nJob:\n${jobDescription}\nRespond JSON {"score":number,"missingKeywords":[],"improvedBullets":[]}`;
   const body = {
@@ -26,9 +41,9 @@ export async function POST(req: Request) {
   const data = await res.json();
   try {
     const text = data.choices[0].message.content;
-    const parsed = JSON.parse(text);
-    return NextResponse.json(parsed);
+    const parsed = JSON.parse(text) as MatchSuccess;
+    return NextResponse.json<MatchSuccess>(parsed);
   } catch (e) {
-    return NextResponse.json({ error: 'Parsing failed' }, { status: 500 });
+    return NextResponse.json<MatchError>({ error: 'Parsing failed' }, { status: 500 });
   }
 }

--- a/app/api/process/route.ts
+++ b/app/api/process/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest } from 'next/server';
 
+interface ProcessRequest {
+  jobId: string;
+}
+
+interface ProcessResponse {
+  jobId: string;
+}
+
 export async function POST(req: NextRequest) {
-  const { jobId } = await req.json();
-  return Response.json({ jobId });
+  const { jobId } = (await req.json()) as ProcessRequest;
+  return Response.json<ProcessResponse>({ jobId });
 }

--- a/app/api/status/route.ts
+++ b/app/api/status/route.ts
@@ -1,3 +1,5 @@
+import type { JobProgress } from '@/types/job';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
@@ -11,22 +13,29 @@ export async function GET(req: Request) {
       let percent = 0;
       const interval = setInterval(() => {
         percent += 10;
-        const progress = {
-          phase: 'processing',
+        const progress: JobProgress = {
+          jobId,
+          phase: 'process',
           percent,
           bytesDone: percent,
           bytesTotal: 100,
           etaSeconds: Math.max(0, (100 - percent) / 10),
         };
         controller.enqueue(
-          `event: progress\n` +
-            `data: ${JSON.stringify(progress)}\n\n`
+          `event: progress\n` + `data: ${JSON.stringify(progress)}\n\n`
         );
         if (percent >= 100) {
           clearInterval(interval);
+          const done: JobProgress = {
+            jobId,
+            phase: 'done',
+            percent: 100,
+            bytesDone: 100,
+            bytesTotal: 100,
+            downloadUrl: `/api/download/${jobId}`,
+          };
           controller.enqueue(
-            `event: done\n` +
-              `data: ${JSON.stringify({ downloadUrl: `/api/download/${jobId}` })}\n\n`
+            `event: done\n` + `data: ${JSON.stringify(done)}\n\n`
           );
           controller.close();
         }

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest } from 'next/server';
 
+interface UploadResponse {
+  jobId: string;
+  filename: string;
+  size: number;
+}
+
 export async function POST(req: NextRequest) {
   const form = await req.formData();
   const file = form.get('file') as File | null;
@@ -12,5 +18,5 @@ export async function POST(req: NextRequest) {
     (global as any)._jobs = (global as any)._jobs || {};
     (global as any)._jobs[jobId] = { filename: file.name, size: file.size };
   }
-  return Response.json({ jobId, filename: file.name, size: file.size });
+  return Response.json<UploadResponse>({ jobId, filename: file.name, size: file.size });
 }

--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
+import type { Metadata } from 'next';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'ATS-ready CV Toolkit',
   description: 'Private client-side CV tools. No uploads.',
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,11 @@
 import '../styles/globals.css';
 import React from 'react';
+import type { Metadata } from 'next';
 import AppErrorBoundary from '@/components/AppErrorBoundary';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'PDF Tool Site',
   description: 'Client-side PDF utilities'
 };

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,16 +1,18 @@
-import { siteConfig } from "@/config/site";
-export default function manifest() {
+import { siteConfig } from '@/config/site';
+import type { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
   return {
     name: siteConfig.name,
     short_name: siteConfig.name,
     description: siteConfig.description,
-    start_url: "/",
-    display: "standalone",
-    background_color: "#ffffff",
-    theme_color: "#2563eb",
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#ffffff',
+    theme_color: '#2563eb',
     icons: [
-      { src: "/icon", sizes: "64x64", type: "image/png" },
-      { src: "/apple-icon", sizes: "180x180", type: "image/png", purpose: "any" }
-    ]
+      { src: '/icon', sizes: '64x64', type: 'image/png' },
+      { src: '/apple-icon', sizes: '180x180', type: 'image/png', purpose: 'any' },
+    ],
   };
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint -c .eslintrc.cjs ."
   },
   "dependencies": {
     "next": "13.5.5",
@@ -19,13 +21,18 @@
   },
   "devDependencies": {
     "@netlify/plugin-nextjs": "^5.0.0",
-    "typescript": "5.2.2",
+    "@types/node": "20.8.4",
     "@types/react": "18.2.37",
     "@types/react-dom": "18.2.15",
-    "@types/node": "20.8.4",
-    "postcss": "8.4.31",
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
     "autoprefixer": "10.4.14",
+    "eslint": "^8.50.0",
+    "eslint-plugin-import": "^2.27.5",
+    "postcss": "8.4.31",
+    "prettier": "^3.0.0",
     "tailwindcss": "3.3.5",
+    "typescript": "5.2.2",
     "vitest": "0.34.6"
   }
 }

--- a/src/lib/jobTypes.ts
+++ b/src/lib/jobTypes.ts
@@ -1,19 +1,9 @@
+import type { ErrorCode } from '@/types/job';
+
 export type JobState = 'IDLE' | 'UPLOADING' | 'PROCESSING' | 'DONE' | 'ERROR';
 
-export interface ProgressInfo {
-  phase: 'upload' | 'processing';
-  percent: number;
-  bytesDone: number;
-  bytesTotal: number;
-  etaSeconds: number;
-}
-
-export interface DoneInfo {
-  downloadUrl: string;
-}
-
 export interface ErrorInfo {
-  code: string;
+  code: ErrorCode;
   message: string;
 }
 

--- a/src/lib/uploadWithProgress.ts
+++ b/src/lib/uploadWithProgress.ts
@@ -1,10 +1,23 @@
+export interface UploadProgress {
+  percent: number;
+  bytesDone: number;
+  bytesTotal: number;
+  etaSeconds: number;
+}
+
+export interface UploadResult {
+  jobId: string;
+  filename: string;
+  size: number;
+}
+
 export async function uploadWithProgress(
   file: File,
-  onProgress: (info: { percent: number; bytesDone: number; bytesTotal: number; etaSeconds: number }) => void,
+  onProgress: (info: UploadProgress) => void,
   signal?: AbortSignal
-) {
+): Promise<UploadResult> {
   const start = Date.now();
-  return new Promise<{ jobId: string; filename: string; size: number }>((resolve, reject) => {
+  return new Promise<UploadResult>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     xhr.open('POST', '/api/upload');
     xhr.responseType = 'json';

--- a/src/lib/useSSE.ts
+++ b/src/lib/useSSE.ts
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from 'react';
-import { ProgressInfo, DoneInfo, ErrorInfo } from './jobTypes';
+import type { JobProgress } from '@/types/job';
 
 interface Handlers {
-  onProgress: (p: ProgressInfo) => void;
-  onDone: (d: DoneInfo) => void;
-  onError: (e: ErrorInfo) => void;
+  onProgress: (p: JobProgress) => void;
+  onDone: (d: JobProgress) => void;
+  onError: (e: JobProgress) => void;
 }
 
 export default function useSSE(jobId: string | undefined, handlers: Handlers) {
@@ -17,14 +17,14 @@ export default function useSSE(jobId: string | undefined, handlers: Handlers) {
       const src = new EventSource(`/api/status?jobId=${jobId}`);
       sourceRef.current = src;
       src.addEventListener('progress', (e) => {
-        handlers.onProgress(JSON.parse((e as MessageEvent).data));
+        handlers.onProgress(JSON.parse((e as MessageEvent<string>).data) as JobProgress);
       });
       src.addEventListener('done', (e) => {
-        handlers.onDone(JSON.parse((e as MessageEvent).data));
+        handlers.onDone(JSON.parse((e as MessageEvent<string>).data) as JobProgress);
       });
       src.addEventListener('error', (e) => {
-        const data = (e as MessageEvent).data;
-        if (data) handlers.onError(JSON.parse(data));
+        const data = (e as MessageEvent<string>).data;
+        if (data) handlers.onError(JSON.parse(data) as JobProgress);
       });
       src.onerror = () => {
         src.close();

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,0 +1,10 @@
+declare namespace NodeJS {
+  interface ProcessEnv {
+    ENABLE_ANALYTICS?: string;
+    NEXT_PUBLIC_ANALYTICS_ID?: string;
+    MOCK_PROGRESS?: string;
+    OPENAI_API_KEY?: string;
+    NODE_ENV: 'development' | 'production' | 'test';
+  }
+}
+

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -1,0 +1,20 @@
+export type JobPhase = 'idle' | 'upload' | 'process' | 'done' | 'error';
+
+export type ErrorCode =
+  | 'E_UNSUPPORTED_TYPE'
+  | 'E_TOO_LARGE'
+  | 'E_UPLOAD_FAIL'
+  | 'E_PROCESS_FAIL'
+  | 'E_STATUS_LOST';
+
+export interface JobProgress {
+  jobId: string;
+  phase: JobPhase;
+  percent: number;
+  bytesDone?: number;
+  bytesTotal?: number;
+  etaSeconds?: number;
+  downloadUrl?: string;
+  error?: { code: ErrorCode; message: string };
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,43 +1,26 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext",
-      "webworker"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": false,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "jsx": "preserve",
-    "incremental": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "allowJs": true,
+    "checkJs": false,
+    "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "src/*"
-      ]
+      "@/*": ["./src/*"],
+      "@/components/*": ["./src/components/*"],
+      "@/config/*": ["./src/config/*"]
     },
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
+    "types": ["node"],
+    "plugins": [{ "name": "next" }]
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }
+


### PR DESCRIPTION
## Summary
- add strict tsconfig with path aliases and env/job types
- type API routes, SSE hook, and upload util with JobProgress
- annotate page metadata and manifest for Next.js

## Testing
- `npm run lint` *(fails: parser key not supported in flat config)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e053fd42c832fafaf16ba5291822a