### PR TITLE
Add progress indicators to PDF tools and fix job storage

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -9,8 +9,8 @@ export async function POST(req: NextRequest) {
   const jobId = crypto.randomUUID();
   if (typeof window === 'undefined') {
     // store minimal info in memory for mock resume
-    (global as any)._jobs = (global as any)._jobs || {};
-    (global as any)._jobs[jobId] = { filename: file.name, size: file.size };
+    (globalThis as any)._jobs = (globalThis as any)._jobs || {};
+    (globalThis as any)._jobs[jobId] = { filename: file.name, size: file.size };
   }
   return Response.json({ jobId, filename: file.name, size: file.size });
 }

--- a/app/tools/compress/page.tsx
+++ b/app/tools/compress/page.tsx
@@ -2,20 +2,27 @@
 import React, { useState } from 'react';
 import { PDFDocument } from 'pdf-lib';
 import UploadArea from '../../../components/UploadArea';
+import ProgressBar from '../../../components/ProgressBar';
 
 export default function CompressPage() {
   const [processing, setProcessing] = useState(false);
   const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
   const [quality, setQuality] = useState(0.7);
+  const [progress, setProgress] = useState(0);
 
   const handleFiles = async (files: FileList) => {
     const file = files[0];
     if (!file) return;
     setProcessing(true);
+    setProgress(0);
     try {
+      setProgress(20);
       const bytes = await file.arrayBuffer();
+      setProgress(40);
       const pdf = await PDFDocument.load(bytes);
+      setProgress(70);
       const compressedBytes = await pdf.save({ useObjectStreams: true });
+      setProgress(100);
       const blob = new Blob([compressedBytes], { type: 'application/pdf' });
       setDownloadUrl(URL.createObjectURL(blob));
     } catch (e) {
@@ -41,7 +48,7 @@ export default function CompressPage() {
         <span className="ml-2">{quality}</span>
       </div>
       <UploadArea onFiles={handleFiles} accept="application/pdf" />
-      {processing && <p>Processing...</p>}
+      {processing && <ProgressBar value={progress} />}
       {downloadUrl && (
         <a
           href={downloadUrl}


### PR DESCRIPTION
## Summary
- add progress bars to PDF tool pages (merge, compress, split, extract text)
- store mock upload jobs on `globalThis` in upload API

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e0d5b7e08832fb391c56e70901134