### PR TITLE
chore: convert next config to typescript

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
-import type { NextConfig } from 'next';
-
-const nextConfig: NextConfig = {
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
   output: 'standalone',
   trailingSlash: false,
   webpack: (config) => {
@@ -8,4 +9,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+module.exports = nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
   output: 'standalone',
   trailingSlash: false,
   webpack: (config) => {
@@ -7,4 +8,4 @@ const nextConfig = {
   },
 };
 
-module.exports = nextConfig;
+export default nextConfig;


### PR DESCRIPTION
## Summary
- convert Next.js config to TypeScript with typed `NextConfig`

## Testing
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e13ede154832f89d41e3a3b65ae7b