### PR TITLE
fix: dedupe react and add error boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint . --ext .ts,.tsx"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^4.3.136"
   },

--- a/src/AppErrorBoundary.tsx
+++ b/src/AppErrorBoundary.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: unknown;
+}
+
+export default class AppErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: unknown): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: unknown) {
+    console.error(error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <pre>{String(this.state.error)}</pre>;
+    }
+    return this.props.children;
+  }
+}

--- a/src/app/routes/Compress.tsx
+++ b/src/app/routes/Compress.tsx
@@ -7,7 +7,7 @@ import { downloadBuffer } from "@/pdf/utils";
 
 export default function CompressRoute() {
   const [WorkerCtor, setWorkerCtor] = useState<null | (new () => Worker)>(null);
-  const worker = WorkerCtor ? useWorker(WorkerCtor) : null;
+  const worker = useWorker(WorkerCtor);
 
   useEffect(() => {
     import("@/pdf/workers/compress.worker.ts?worker").then((m) => setWorkerCtor(() => m.default));

--- a/src/hooks/useWorker.ts
+++ b/src/hooks/useWorker.ts
@@ -5,7 +5,7 @@ export type WorkerEvent =
   | { type: "result"; data: ArrayBuffer | ArrayBuffer[] }
   | { type: "error"; message: string };
 
-export function useWorker(WorkerCtor: new () => Worker) {
+export function useWorker(WorkerCtor: null | (new () => Worker)) {
   const workerRef = useRef<Worker | null>(null);
   const [progress, setProgress] = useState(0);
   const [status, setStatus] = useState<"idle" | "working" | "done" | "error">("idle");
@@ -13,6 +13,7 @@ export function useWorker(WorkerCtor: new () => Worker) {
   const [result, setResult] = useState<ArrayBuffer | ArrayBuffer[] | null>(null);
 
   useEffect(() => {
+    if (!WorkerCtor) return;
     const w = new WorkerCtor();
     workerRef.current = w;
     w.onmessage = (e: MessageEvent<WorkerEvent>) => {
@@ -36,6 +37,8 @@ export function useWorker(WorkerCtor: new () => Worker) {
     setResult(null);
     workerRef.current?.postMessage(payload);
   };
+
+  if (!WorkerCtor) return null;
 
   return { run, progress, status, error, result };
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import CompressRoute from "./app/routes/Compress";
+import AppErrorBoundary from "./AppErrorBoundary";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <CompressRoute />
+    <AppErrorBoundary>
+      <CompressRoute />
+    </AppErrorBoundary>
   </React.StrictMode>
 );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,6 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
-  worker: { format: "es" }
+  worker: { format: "es" },
+  resolve: { dedupe: ["react", "react-dom"] }
 });


### PR DESCRIPTION
## Summary
- pin React dependencies and dedupe in Vite config
- ensure hooks are invoked unconditionally
- wrap app in a temporary error boundary for previews

## Testing
- `pnpm i` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_689ea7dba89c832f85f493d9eaf131a2