### PR TITLE
feat: ui polish for ATS CV Toolkit

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>PDF Tool</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ATS CV Toolkit</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,0 +1,15 @@
+import { Link } from "./Link";
+export default function Footer() {
+  return (
+    <footer className="footer container" role="contentinfo">
+      <div style={{display:"flex",justifyContent:"space-between",gap:12,flexWrap:"wrap"}}>
+        <span>© {new Date().getFullYear()} nouploadpdf.com — 100% on-device</span>
+        <div className="nav" style={{gap:12}}>
+          <Link href="/privacy">Privacy</Link>
+          <Link href="/security">Security</Link>
+          <Link href="/changelog">Changelog</Link>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,0 +1,21 @@
+import { Link } from "./Link";
+
+export default function Header() {
+  return (
+    <header className="header container" role="banner">
+      <Link href="/" className="brand" ariaLabel="nouploadpdf.com Home">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path fill="currentColor" d="M3 5h12l6 6v8a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2zm11 0v5h5" />
+        </svg>
+        <strong>ATS CV Toolkit</strong>
+      </Link>
+      <nav className="nav" aria-label="Primary">
+        <Link href="/#tools">Tools</Link>
+        <Link href="/why-ats">Why ATS</Link>
+        <Link href="/privacy">Privacy</Link>
+        <Link href="/security">Security</Link>
+        <Link href="/faq">FAQ</Link>
+      </nav>
+    </header>
+  );
+}

--- a/src/app/components/Link.tsx
+++ b/src/app/components/Link.tsx
@@ -1,0 +1,8 @@
+type Props = React.PropsWithChildren<{ href: string; className?: string; ariaLabel?: string }>
+export function Link({ href, className, children, ariaLabel }: Props) {
+  return (
+    <a className={className} href={href} aria-label={ariaLabel}>
+      {children}
+    </a>
+  )
+}

--- a/src/app/hooks/useMeta.ts
+++ b/src/app/hooks/useMeta.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+interface MetaOptions {
+  title: string;
+  description?: string;
+}
+
+export function useMeta({ title, description }: MetaOptions) {
+  useEffect(() => {
+    if (title) document.title = title;
+    if (description) {
+      let tag = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+      if (!tag) {
+        tag = document.createElement('meta');
+        tag.name = 'description';
+        document.head.appendChild(tag);
+      }
+      tag.content = description;
+    }
+  }, [title, description]);
+}

--- a/src/app/routes/Changelog.tsx
+++ b/src/app/routes/Changelog.tsx
@@ -1,16 +1,24 @@
+import Header from "@/app/components/Header";
+import Footer from "@/app/components/Footer";
+import { useMeta } from "@/app/hooks/useMeta";
 import changes from "./changelog.json";
 
 export default function Changelog() {
+  useMeta({ title: "Changelog - ATS CV Toolkit", description: "Release history and updates" });
   return (
-    <main>
-      <h2>Changelog</h2>
-      <ul>
-        {changes.map((c) => (
-          <li key={c.date}>
-            <strong>{c.date}</strong> - {c.text}
-          </li>
-        ))}
-      </ul>
-    </main>
+    <>
+      <Header />
+      <main className="container">
+        <h2>Changelog</h2>
+        <ul>
+          {changes.map((c) => (
+            <li key={c.date}>
+              <strong>{c.date}</strong> - {c.text}
+            </li>
+          ))}
+        </ul>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/src/app/routes/Faq.tsx
+++ b/src/app/routes/Faq.tsx
@@ -1,13 +1,38 @@
+import Header from "@/app/components/Header";
+import Footer from "@/app/components/Footer";
+import { useMeta } from "@/app/hooks/useMeta";
+
 export default function Faq() {
+  useMeta({ title: "FAQ - ATS CV Toolkit", description: "Common questions about using the toolkit" });
   return (
-    <main>
-      <h2>FAQ</h2>
-      <dl>
-        <dt>Why is my PDF still large?</dt>
-        <dd>Some PDFs contain high-resolution images that limit compression.</dd>
-        <dt>Do you store my files?</dt>
-        <dd>No. Files stay in your browser memory.</dd>
-      </dl>
-    </main>
+    <>
+      <Header />
+      <main className="container">
+        <h2>FAQ</h2>
+        <dl>
+          <dt>What file size should my CV be?</dt>
+          <dd>Aim for under 2MB; some portals require under 1MB.</dd>
+          <dt>Which fonts work best?</dt>
+          <dd>Stick to system fonts like Arial, Times New Roman, or Roboto.</dd>
+          <dt>Can I use tables and columns?</dt>
+          <dd>Simple tables are fine but complex layouts can confuse ATS parsing.</dd>
+          <dt>What about headers and footers?</dt>
+          <dd>Keep them minimal and avoid placing key info there.</dd>
+          <dt>Does compression reduce quality?</dt>
+          <dd>Text stays sharp; only large images are resized.</dd>
+          <dt>Will OCR handle any language?</dt>
+          <dd>OCR currently supports English and Vietnamese.</dd>
+          <dt>How do I verify it works offline?</dt>
+          <dd>Open a tool, switch to airplane mode, then refresh. The app still runs.</dd>
+          <dt>Are my files ever uploaded?</dt>
+          <dd>No. Processing happens entirely in your browser.</dd>
+          <dt>Why might a portal reject my CV?</dt>
+          <dd>Large sizes, uncommon fonts, or locked PDFs may cause issues.</dd>
+          <dt>How do I merge multiple PDFs?</dt>
+          <dd>Use the Merge tool, drop your files, drag to reorder, then download.</dd>
+        </dl>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -1,18 +1,46 @@
+import Header from "@/app/components/Header";
+import Footer from "@/app/components/Footer";
+import { Link } from "@/app/components/Link";
+import { useMeta } from "@/app/hooks/useMeta";
+
 export default function Home() {
+  useMeta({ title: "ATS CV Toolkit", description: "Fast, private CV PDF tools" });
   return (
-    <main>
-      <h1>Fast, Private CV PDF tools</h1>
-      <p>ATS-ready in minutes. No upload, no sign-up.</p>
-      <nav>
-        <ul>
-          <li><a href="/cv/compress">Compress</a></li>
-          <li><a href="/cv/merge">Merge</a></li>
-          <li><a href="/cv/ats-export">ATS Export</a></li>
-          <li><a href="/cv/ocr">OCR</a></li>
-          <li><a href="/cv/jd-match">JD Match</a></li>
-        </ul>
-      </nav>
-      <p><a href="/cv/compress">Get Started</a></p>
-    </main>
+    <>
+      <Header />
+      <main className="container">
+        <section className="hero">
+          <h1>Fast, Private CV PDF tools</h1>
+          <p>ATS-ready in minutes. No upload, no sign-up.</p>
+          <div style={{marginTop:12, display:"flex", gap:10, flexWrap:"wrap"}}>
+            <a className="btn" href="#tools">Get Started</a>
+            <Link className="btn ghost" href="/why-ats">Why ATS</Link>
+          </div>
+        </section>
+
+        <section id="tools" style={{marginTop:18}}>
+          <div className="grid grid-3">
+            {cards.map((c) => (
+              <article key={c.href} className="card">
+                <h3 style={{marginTop:0}}>{c.title}</h3>
+                <p style={{color:"var(--muted)", marginTop:4}}>{c.desc}</p>
+                <div style={{marginTop:10}}>
+                  <a className="btn" href={c.href} aria-label={`Open ${c.title}`}>Open</a>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
   );
 }
+
+const cards = [
+  { title: "Compress", desc: "Target <2MB / <1MB for job portals.", href: "/cv/compress" },
+  { title: "Merge", desc: "Combine CV + portfolio and reorder pages.", href: "/cv/merge" },
+  { title: "ATS Export", desc: "Extract clean TXT ready for ATS parsers.", href: "/cv/ats-export" },
+  { title: "OCR (EN/VI)", desc: "Turn scanned CVs into editable text.", href: "/cv/ocr" },
+  { title: "JD Match (AI)", desc: "Find missing keywords and get bullet tips.", href: "/cv/jd-match" },
+];

--- a/src/app/routes/Privacy.tsx
+++ b/src/app/routes/Privacy.tsx
@@ -1,8 +1,18 @@
+import Header from "@/app/components/Header";
+import Footer from "@/app/components/Footer";
+import { useMeta } from "@/app/hooks/useMeta";
+
 export default function Privacy() {
+  useMeta({ title: "Privacy - ATS CV Toolkit", description: "We do not upload or store your files." });
   return (
-    <main>
-      <h2>Privacy</h2>
-      <p>Processing happens entirely in your browser. Files are never uploaded.</p>
-    </main>
+    <>
+      <Header />
+      <main className="container">
+        <h2>Privacy</h2>
+        <p>We do not upload or store your files. Everything happens in your browser memory.</p>
+        <p>No cookies are set by default. Optional analytics is off.</p>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/src/app/routes/Security.tsx
+++ b/src/app/routes/Security.tsx
@@ -1,8 +1,22 @@
+import Header from "@/app/components/Header";
+import Footer from "@/app/components/Footer";
+import { useMeta } from "@/app/hooks/useMeta";
+
 export default function Security() {
+  useMeta({
+    title: "Security - ATS CV Toolkit",
+    description: "On-device processing with Web Workers and transferable buffers",
+  });
   return (
-    <main>
-      <h2>Security</h2>
-      <p>Work happens in Web Workers with ArrayBuffer transfer to keep data in memory only.</p>
-    </main>
+    <>
+      <Header />
+      <main className="container">
+        <h2>Security</h2>
+        <p>All processing runs on your device using Web Workers. ArrayBuffers are transferred, not copied, so data stays in memory only as long as needed.</p>
+        <p>After each task, memory is released and nothing touches our servers.</p>
+        <p>The site works offline once loaded. Switch to airplane mode to verify.</p>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/src/app/routes/WhyAts.tsx
+++ b/src/app/routes/WhyAts.tsx
@@ -1,8 +1,23 @@
+import Header from "@/app/components/Header";
+import Footer from "@/app/components/Footer";
+import { useMeta } from "@/app/hooks/useMeta";
+
 export default function WhyAts() {
+  useMeta({
+    title: "Why ATS - ATS CV Toolkit",
+    description: "How applicant tracking systems read your PDF and why on-device tools matter",
+  });
   return (
-    <main>
-      <h2>Why ATS-ready PDFs</h2>
-      <p>ATS systems scan your CV. Clean, simple PDFs help ensure your skills are seen.</p>
-    </main>
+    <>
+      <Header />
+      <main className="container">
+        <h2>Why ATS-ready PDFs</h2>
+        <p>Applicant Tracking Systems (ATS) scan your CV before a human does. They extract text and compare it with job description keywords.</p>
+        <p>Most job portals cap uploads at 2MB, some at 1MB. Keep images small and remove unnecessary pages.</p>
+        <p>Use common fonts like Arial, Times New Roman, or Roboto. Exotic or unembedded fonts can disappear during parsing.</p>
+        <p>Our tools work entirely on your device. Nothing is uploaded, so your private information stays with you.</p>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/src/app/routes/cv/AtsExport.tsx
+++ b/src/app/routes/cv/AtsExport.tsx
@@ -5,8 +5,12 @@ import Toast from "@/app/components/Toast";
 import { useWorker } from "@/app/hooks/useWorker";
 import ExportWorker from "@/pdf/workers/exportText.worker?worker";
 import { downloadText } from "@/pdf/utils";
+import Header from "@/app/components/Header";
+import Footer from "@/app/components/Footer";
+import { useMeta } from "@/app/hooks/useMeta";
 
 export default function AtsExport() {
+  useMeta({ title: "ATS Export - ATS CV Toolkit", description: "Extract text ready for ATS parsers" });
   const { run, progress, status, error, result } = useWorker(ExportWorker);
   const [text, setText] = useState("");
 
@@ -22,21 +26,25 @@ export default function AtsExport() {
   }, [status, result]);
 
   return (
-    <div>
-      <h2>ATS Export</h2>
-      <Dropzone onFile={handleFile} />
-      {status === "working" && <ProgressBar progress={progress} />}
-      {error && <Toast message={error} onClose={() => {}} />}
-      {text && (
-        <div>
-          <textarea value={text} readOnly rows={10} cols={40} />
+    <>
+      <Header />
+      <main className="container">
+        <h2>ATS Export</h2>
+        <Dropzone onFile={handleFile} />
+        {status === "working" && <ProgressBar progress={progress} />}
+        {error && <Toast message={error} onClose={() => {}} />}
+        {text && (
           <div>
-            <button onClick={() => navigator.clipboard.writeText(text)}>Copy</button>
-            <button onClick={() => downloadText(text, "cv.txt")}>Download</button>
+            <textarea value={text} readOnly rows={10} cols={40} />
+            <div style={{marginTop:8,display:"flex",gap:8,flexWrap:"wrap"}}>
+              <button className="btn" onClick={() => navigator.clipboard.writeText(text)}>Copy</button>
+              <button className="btn" onClick={() => downloadText(text, "cv.txt")}>Download</button>
+            </div>
           </div>
-        </div>
-      )}
-      <aside>Tip: Avoid headers/footers and tables for ATS.</aside>
-    </div>
+        )}
+        <aside style={{marginTop:12,color:"var(--muted)"}}>Tip: Avoid headers/footers and tables for ATS.</aside>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/src/app/routes/cv/Compress.tsx
+++ b/src/app/routes/cv/Compress.tsx
@@ -5,8 +5,12 @@ import Toast from "@/app/components/Toast";
 import { useWorker } from "@/app/hooks/useWorker";
 import { downloadBuffer } from "@/pdf/utils";
 import CompressWorker from "@/pdf/workers/compressCv.worker?worker";
+import Header from "@/app/components/Header";
+import Footer from "@/app/components/Footer";
+import { useMeta } from "@/app/hooks/useMeta";
 
 export default function Compress() {
+  useMeta({ title: "Compress PDF - ATS CV Toolkit", description: "Shrink your CV without uploading." });
   const { run, progress, status, error, result } = useWorker(CompressWorker);
 
   const handleFile = async (file: File) => {
@@ -21,12 +25,16 @@ export default function Compress() {
   }, [status, result]);
 
   return (
-    <div>
-      <h2>Compress PDF</h2>
-      <Dropzone onFile={handleFile} />
-      {status === "working" && <ProgressBar progress={progress} />}
-      {error && <Toast message={error} onClose={() => {}} />}
-      <aside>Tip: Keep under 2MB for LinkedIn.</aside>
-    </div>
+    <>
+      <Header />
+      <main className="container">
+        <h2>Compress PDF</h2>
+        <Dropzone onFile={handleFile} />
+        {status === "working" && <ProgressBar progress={progress} />}
+        {error && <Toast message={error} onClose={() => {}} />}
+        <aside style={{marginTop:12,color:"var(--muted)"}}>Tip: Keep under 2MB for LinkedIn.</aside>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/src/app/routes/cv/JdMatch.tsx
+++ b/src/app/routes/cv/JdMatch.tsx
@@ -1,4 +1,7 @@
 import { useState } from "react";
+import Header from "@/app/components/Header";
+import Footer from "@/app/components/Footer";
+import { useMeta } from "@/app/hooks/useMeta";
 
 interface Result {
   score: number;
@@ -6,6 +9,7 @@ interface Result {
 }
 
 export default function JdMatch() {
+  useMeta({ title: "JD Match - ATS CV Toolkit", description: "Find missing keywords from job descriptions" });
   const [jd, setJd] = useState("");
   const [cv, setCv] = useState("");
   const [result, setResult] = useState<Result | null>(null);
@@ -33,31 +37,35 @@ export default function JdMatch() {
   const aiEnabled = import.meta.env.VITE_AI_ENABLED === "true";
 
   return (
-    <div>
-      <h2>JD Match</h2>
-      {!aiEnabled && <p>AI disabled in this build.</p>}
-      <textarea
-        placeholder="Paste Job Description"
-        value={jd}
-        onChange={(e) => setJd(e.target.value)}
-        rows={8}
-        cols={40}
-      />
-      <textarea
-        placeholder="Paste your CV text"
-        value={cv}
-        onChange={(e) => setCv(e.target.value)}
-        rows={8}
-        cols={40}
-      />
-      <button onClick={runMatch}>Match</button>
-      {result && (
-        <div>
-          <p>Score: {result.score}</p>
-          <p>Missing keywords: {result.missing.join(", ")}</p>
-        </div>
-      )}
-      <aside>Tip: Highlight missing keywords in your CV.</aside>
-    </div>
+    <>
+      <Header />
+      <main className="container">
+        <h2>JD Match</h2>
+        {!aiEnabled && <p>AI disabled in this build.</p>}
+        <textarea
+          placeholder="Paste Job Description"
+          value={jd}
+          onChange={(e) => setJd(e.target.value)}
+          rows={8}
+          cols={40}
+        />
+        <textarea
+          placeholder="Paste your CV text"
+          value={cv}
+          onChange={(e) => setCv(e.target.value)}
+          rows={8}
+          cols={40}
+        />
+        <button className="btn" onClick={runMatch}>Match</button>
+        {result && (
+          <div>
+            <p>Score: {result.score}</p>
+            <p>Missing keywords: {result.missing.join(", ")}</p>
+          </div>
+        )}
+        <aside style={{marginTop:12,color:"var(--muted)"}}>Tip: Highlight missing keywords in your CV.</aside>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/src/app/routes/cv/Merge.tsx
+++ b/src/app/routes/cv/Merge.tsx
@@ -6,8 +6,12 @@ import FileList from "@/app/components/FileList";
 import { useWorker } from "@/app/hooks/useWorker";
 import { downloadBuffer } from "@/pdf/utils";
 import MergeWorker from "@/pdf/workers/mergeCv.worker?worker";
+import Header from "@/app/components/Header";
+import Footer from "@/app/components/Footer";
+import { useMeta } from "@/app/hooks/useMeta";
 
 export default function Merge() {
+  useMeta({ title: "Merge PDFs - ATS CV Toolkit", description: "Combine CV and portfolio on-device" });
   const { run, progress, status, error, result } = useWorker(MergeWorker);
   const [files, setFiles] = useState<File[]>([]);
 
@@ -27,14 +31,20 @@ export default function Merge() {
   }, [status, result]);
 
   return (
-    <div>
-      <h2>Merge PDFs</h2>
-      <Dropzone onFile={handleFile} />
-      {files.length > 0 && <FileList files={files} onReorder={setFiles} />}
-      {files.length > 1 && <button onClick={startMerge}>Merge</button>}
-      {status === "working" && <ProgressBar progress={progress} />}
-      {error && <Toast message={error} onClose={() => {}} />}
-      <aside>Tip: Merge CV and portfolio then reorder.</aside>
-    </div>
+    <>
+      <Header />
+      <main className="container">
+        <h2>Merge PDFs</h2>
+        <Dropzone onFile={handleFile} />
+        {files.length > 0 && <FileList files={files} onReorder={setFiles} />}
+        {files.length > 1 && (
+          <button className="btn" onClick={startMerge}>Merge</button>
+        )}
+        {status === "working" && <ProgressBar progress={progress} />}
+        {error && <Toast message={error} onClose={() => {}} />}
+        <aside style={{marginTop:12,color:"var(--muted)"}}>Tip: Merge CV and portfolio then reorder.</aside>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/src/app/routes/cv/Ocr.tsx
+++ b/src/app/routes/cv/Ocr.tsx
@@ -4,8 +4,12 @@ import ProgressBar from "@/app/components/ProgressBar";
 import Toast from "@/app/components/Toast";
 import { useWorker } from "@/app/hooks/useWorker";
 import OcrWorker from "@/pdf/workers/ocrCv.worker?worker";
+import Header from "@/app/components/Header";
+import Footer from "@/app/components/Footer";
+import { useMeta } from "@/app/hooks/useMeta";
 
 export default function Ocr() {
+  useMeta({ title: "OCR - ATS CV Toolkit", description: "Turn scanned CVs into editable text" });
   const { run, progress, status, error, result } = useWorker(OcrWorker);
   const [text, setText] = useState("");
   const [lang, setLang] = useState<'eng' | 'vie'>('eng');
@@ -31,20 +35,24 @@ export default function Ocr() {
   }, [status, result]);
 
   return (
-    <div>
-      <h2>OCR</h2>
-      <label>
-        Language:
-        <select value={lang} onChange={(e) => setLang(e.target.value as 'eng' | 'vie')}>
-          <option value="eng">English</option>
-          <option value="vie">Vietnamese</option>
-        </select>
-      </label>
-      <Dropzone onFile={handleFile} />
-      {status === "working" && <ProgressBar progress={progress} />}
-      {error && <Toast message={error} onClose={() => {}} />}
-      {text && <textarea value={text} readOnly rows={10} cols={40} />}
-      <aside>OCR quality varies; re-type critical sections.</aside>
-    </div>
+    <>
+      <Header />
+      <main className="container">
+        <h2>OCR</h2>
+        <label style={{display:"block",marginBottom:8}}>
+          Language:
+          <select value={lang} onChange={(e) => setLang(e.target.value as 'eng' | 'vie')}>
+            <option value="eng">English</option>
+            <option value="vie">Vietnamese</option>
+          </select>
+        </label>
+        <Dropzone onFile={handleFile} />
+        {status === "working" && <ProgressBar progress={progress} />}
+        {error && <Toast message={error} onClose={() => {}} />}
+        {text && <textarea value={text} readOnly rows={10} cols={40} />}
+        <aside style={{marginTop:12,color:"var(--muted)"}}>OCR quality varies; re-type critical sections.</aside>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,8 @@
 import React, { Suspense, lazy } from "react";
 import ReactDOM from "react-dom/client";
 import AppErrorBoundary from "./AppErrorBoundary";
+import "./ui/theme.css";
+import "./ui/ui.css";
 
 const routes: Record<string, () => Promise<{ default: React.ComponentType<any> }>> = {
   "/": () => import("@/app/routes/Home"),

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -1,0 +1,20 @@
+:root {
+  --bg: #0b0c10;
+  --card: #111319;
+  --muted: #97a1b5;
+  --text: #e9edf3;
+  --brand: #57a6ff;
+  --brand-ink: #001a33;
+  --border: #1a2030;
+  --radius: 16px;
+  --shadow: 0 6px 24px rgba(0,0,0,.25), 0 1px 0 rgba(255,255,255,.03) inset;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f6f7fb;
+    --card: #ffffff;
+    --text: #1b2430;
+    --brand-ink: #eaf3ff;
+    --border: #e7ecf5;
+  }
+}

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -1,0 +1,27 @@
+* { box-sizing: border-box }
+html,body,#root { height: 100% }
+body { margin:0; background:var(--bg); color:var(--text); font:16px/1.6 system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif }
+
+.container { max-width: 1080px; margin: 0 auto; padding: 20px }
+.grid { display:grid; gap:16px }
+@media (min-width: 768px){ .grid-3 { grid-template-columns: repeat(3, minmax(0,1fr)) } }
+
+.card { background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:var(--shadow); padding:18px }
+.btn { display:inline-flex; align-items:center; gap:8px; background:var(--brand); color:var(--brand-ink); border:0; padding:10px 16px; border-radius:12px; font-weight:700; cursor:pointer }
+.btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px }
+.btn.ghost { background:transparent; color:var(--text); border:1px solid var(--border) }
+
+.header { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:12px 0 }
+.brand { display:flex; align-items:center; gap:10px; text-decoration:none; color:inherit }
+.brand svg { width:28px; height:28px }
+.nav { display:flex; gap:14px; flex-wrap:wrap }
+.nav a { text-decoration:none; color:var(--text); opacity:.85 }
+.nav a:hover { opacity:1 }
+
+.hero { padding: 18px; border:1px solid var(--border); border-radius:var(--radius); background:linear-gradient(180deg, rgba(87,166,255,.08), transparent) }
+.hero h1 { margin:0 0 8px 0; font-size: clamp(22px, 5vw, 36px) }
+.hero p { margin:0; color:var(--muted) }
+
+.footer { margin-top: 36px; padding: 14px 0; color: var(--muted); font-size:14px; border-top:1px solid var(--border) }
+.footer a { color: var(--muted); text-decoration: none }
+.footer a:hover { text-decoration: underline }


### PR DESCRIPTION
## Summary
- implement lightweight design system and global theme
- add header/footer navigation and trust pages
- redesign home with hero cards and mobile-first layout

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689eb2115594832f9485a88be4f5d533