### PR TITLE
feat: add smart compression presets and worker pipelines

### DIFF
--- a/src/app/routes/cv/Compress.tsx
+++ b/src/app/routes/cv/Compress.tsx
@@ -2,30 +2,29 @@ import Dropzone from "../../components/Dropzone";
 import ResultDownloadCard from "../../components/ResultDownloadCard";
 import { useWorker } from "../../hooks/useWorker";
 import { deriveOutputName } from "@/pdf/utils";
-import CompressWorker from "@/pdf/workers/compressCv.worker.ts?worker";
+import SmartWorker from "@/pdf/workers/smartCompress.worker.ts?worker";
 import { useState } from "react";
 
 const DBG = import.meta.env.VITE_DEBUG === "true";
 
 export default function CompressPage() {
-  const { run, progress, status, error, result } = useWorker(CompressWorker);
+  const { run, progress, status, error, result } = useWorker(SmartWorker, "smart-compress");
   const [srcFile, setSrcFile] = useState<File | null>(null);
   const [outBlob, setOutBlob] = useState<Blob | null>(null);
   const [outName, setOutName] = useState<string>("");
+  const [preset, setPreset] = useState<'SMART' | 'ATS_SAFE' | 'EMAIL' | 'SMALLEST'>('SMART');
 
   const onPick = async (file: File) => {
     setSrcFile(file);
     setOutBlob(null);
     setOutName("");
-    const buf = await file.arrayBuffer();
     DBG && console.log("[compress] picked", file.name, file.size);
-    run({ file: buf, target: "2mb" }); // could be "1mb" or custom via UI later
+    run({ file, preset });
   };
 
   // Convert worker result to Blob and prepare names
-  if (status === "done" && result instanceof ArrayBuffer && !outBlob) {
-    const blob = new Blob([result], { type: "application/pdf" });
-    setOutBlob(blob);
+  if (status === "done" && result instanceof Blob && !outBlob) {
+    setOutBlob(result);
     setOutName(deriveOutputName(srcFile?.name || "document", "-compressed", ".pdf"));
   }
 
@@ -34,6 +33,25 @@ export default function CompressPage() {
   return (
     <div className="container">
       <h2>Compress</h2>
+      <div style={{ marginBottom: 8 }}>
+        {[
+          { id: "SMART", label: "Smart" },
+          { id: "ATS_SAFE", label: "ATS-safe" },
+          { id: "EMAIL", label: "Email <2MB" },
+          { id: "SMALLEST", label: "Smallest" },
+        ].map((p) => (
+          <label key={p.id} style={{ marginRight: 12 }}>
+            <input
+              type="radio"
+              name="preset"
+              value={p.id}
+              checked={preset === p.id}
+              onChange={() => setPreset(p.id as any)}
+            />{" "}
+            {p.label}
+          </label>
+        ))}
+      </div>
       {!srcFile && <Dropzone onFile={onPick} maxMB={100} />}
 
       {srcFile && status === "working" && (

--- a/src/pdf/pipelines/losslessClean.ts
+++ b/src/pdf/pipelines/losslessClean.ts
@@ -1,0 +1,20 @@
+import { PDFDocument } from 'pdf-lib';
+
+export type PipelineConfig = {
+  dpi?: number;
+  quality?: number;
+  format?: 'jpeg' | 'webp';
+};
+
+export async function losslessClean(
+  ab: ArrayBuffer,
+  _cfg: PipelineConfig,
+  onProgress?: (p: { page: number; total: number; stage: string }) => void
+): Promise<Blob> {
+  const pdf = await PDFDocument.load(ab, { updateMetadata: true });
+  pdf.setProducer('');
+  pdf.setCreator('');
+  const out = await pdf.save({ useObjectStreams: true, addDefaultPage: false });
+  onProgress?.({ page: 1, total: 1, stage: 'compose' });
+  return new Blob([out.buffer as ArrayBuffer], { type: 'application/pdf' });
+}

--- a/src/pdf/pipelines/rasterAll.ts
+++ b/src/pdf/pipelines/rasterAll.ts
@@ -1,0 +1,10 @@
+import { losslessClean, PipelineConfig } from './losslessClean';
+
+export async function rasterAll(
+  ab: ArrayBuffer,
+  cfg: PipelineConfig,
+  onProgress?: (p: { page: number; total: number; stage: string }) => void
+): Promise<Blob> {
+  // Placeholder: reuse losslessClean for now
+  return losslessClean(ab, cfg, onProgress);
+}

--- a/src/pdf/pipelines/searchableImage.ts
+++ b/src/pdf/pipelines/searchableImage.ts
@@ -1,0 +1,10 @@
+import { losslessClean, PipelineConfig } from './losslessClean';
+
+export async function searchableImage(
+  ab: ArrayBuffer,
+  cfg: PipelineConfig,
+  onProgress?: (p: { page: number; total: number; stage: string }) => void
+): Promise<Blob> {
+  // Placeholder: reuse losslessClean for now
+  return losslessClean(ab, cfg, onProgress);
+}

--- a/src/pdf/utils/classifyDoc.ts
+++ b/src/pdf/utils/classifyDoc.ts
@@ -1,0 +1,17 @@
+import { getDocument } from 'pdfjs-dist';
+
+export async function classifyDoc(ab: ArrayBuffer, pagesToProbe = 2) {
+  const pdf = await getDocument({ data: ab }).promise;
+  let textGlyphs = 0, items = 0;
+  const probe = Math.min(pdf.numPages, pagesToProbe);
+  for (let p = 1; p <= probe; p++) {
+    const page = await pdf.getPage(p);
+    const tc = await page.getTextContent();
+    textGlyphs += tc.items.length;
+    items += 1;
+  }
+  const ratio = textGlyphs / Math.max(1, items * 500); // heuristic 500 glyphs/page
+  if (textGlyphs < 10) return { kind: 'SCAN' as const, textGlyphRatio: 0 };
+  if (ratio > 0.8) return { kind: 'TEXT_HEAVY' as const, textGlyphRatio: ratio };
+  return { kind: 'IMAGE_HEAVY' as const, textGlyphRatio: ratio };
+}

--- a/src/pdf/workers/smartCompress.worker.ts
+++ b/src/pdf/workers/smartCompress.worker.ts
@@ -1,0 +1,109 @@
+import { classifyDoc } from '../utils/classifyDoc';
+import { losslessClean } from '../pipelines/losslessClean';
+import { searchableImage } from '../pipelines/searchableImage';
+import { rasterAll } from '../pipelines/rasterAll';
+import type { PipelineConfig } from '../pipelines/losslessClean';
+
+interface WorkerIn {
+  file: File;
+  preset: 'SMART' | 'ATS_SAFE' | 'EMAIL' | 'SMALLEST';
+  opts?: Partial<PipelineConfig & { targetSizeMB?: number }>;
+}
+
+interface Progress {
+  page: number;
+  total: number;
+  stage: string;
+}
+
+function deriveConfigFromPreset(
+  preset: WorkerIn['preset'],
+  kind: 'SCAN' | 'TEXT_HEAVY' | 'IMAGE_HEAVY',
+  opts: any = {}
+) {
+  const cfg: any = { dpi: 150, quality: 0.75, format: 'jpeg', ...opts };
+  switch (preset) {
+    case 'SMALLEST':
+      cfg.dpi = 120;
+      cfg.quality = 0.6;
+      break;
+    case 'EMAIL':
+      cfg.targetSizeMB = cfg.targetSizeMB || 2;
+      break;
+    case 'SMART':
+      if (kind !== 'TEXT_HEAVY') cfg.targetSizeMB = cfg.targetSizeMB || 2;
+      break;
+    case 'ATS_SAFE':
+    default:
+      break;
+  }
+  return cfg;
+}
+
+function selectPipeline(
+  preset: WorkerIn['preset'],
+  kind: 'SCAN' | 'TEXT_HEAVY' | 'IMAGE_HEAVY'
+) {
+  if (preset === 'SMALLEST') return 'rasterAll';
+  if (preset === 'ATS_SAFE') return 'lossless';
+  if (preset === 'EMAIL') return kind === 'TEXT_HEAVY' ? 'lossless' : 'rasterAll';
+  // SMART
+  if (kind === 'TEXT_HEAVY') return 'lossless';
+  if (kind === 'SCAN') return 'searchableImage';
+  return 'rasterAll';
+}
+
+async function runPipeline(
+  name: string,
+  ab: ArrayBuffer,
+  cfg: PipelineConfig,
+  onProgress: (p: Progress) => void
+) {
+  if (name === 'lossless') return losslessClean(ab, cfg, onProgress);
+  if (name === 'searchableImage') return searchableImage(ab, cfg, onProgress);
+  return rasterAll(ab, cfg, onProgress);
+}
+
+async function iterateForTarget(
+  buildOnce: (cfg: any) => Promise<Blob>,
+  startCfg: any,
+  targetBytes: number,
+  maxTries = 3
+) {
+  let best = { blob: await buildOnce(startCfg), cfg: { ...startCfg } };
+  for (let i = 1; i < maxTries; i++) {
+    const cur = best.blob.size;
+    if (cur <= targetBytes) break;
+    const next = { ...best.cfg };
+    next.dpi = Math.max(90, Math.round((next.dpi || 150) * 0.9));
+    next.quality = Math.max(0.5, +(next.quality || 0.75 - 0.05).toFixed(2));
+    const blob = await buildOnce(next);
+    if (blob.size < best.blob.size) best = { blob, cfg: next };
+  }
+  return best;
+}
+
+self.onmessage = async (e: MessageEvent<WorkerIn>) => {
+  const post = (m: any) => (self as any).postMessage(m);
+  try {
+    const { file, preset, opts } = e.data;
+    const ab = await file.arrayBuffer();
+    const { kind } = await classifyDoc(ab);
+    let cfg: any = deriveConfigFromPreset(preset, kind, opts);
+    const pipeline = selectPipeline(preset, kind);
+    const buildOnce = (c: any) =>
+      runPipeline(pipeline, ab, c, (p) => post({ type: 'progress', value: Math.round((p.page / p.total) * 100) }));
+    let blob: Blob;
+    if (cfg.targetSizeMB) {
+      const target = cfg.targetSizeMB * 1024 * 1024;
+      const res = await iterateForTarget(buildOnce, cfg, target);
+      blob = res.blob;
+      cfg = res.cfg;
+    } else {
+      blob = await buildOnce(cfg);
+    }
+    post({ type: 'result', data: blob, meta: { cfg, kind, pipeline } });
+  } catch (err: any) {
+    post({ type: 'error', message: String(err) });
+  }
+};


### PR DESCRIPTION
## Summary
- add four compression presets to CV compress UI
- introduce smart compression worker with basic pipelines and target-size iteration
- add document classifier utility and placeholder pipelines

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:smoke`
- `npm run build:stats`
- `npm run size` *(fails: Missing script "size")*

------
https://chatgpt.com/codex/tasks/task_e_689fbf307dd0832fa9260aafa6bfbc6e