### PR TITLE
feat(ocr,compress): real tesseract.js with fallback; size guard with gzip fallback; samples route and measurement helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,35 +14,37 @@
     "test:smoke": "SMOKE_MODE=lite playwright test -c playwright.config.ts",
     "test:smoke:full": "playwright test",
     "postinstall": "playwright install --with-deps || true",
-    "size": "size-limit"
+    "size": "node scripts/size-guard.mjs || size-limit"
   },
   "dependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "jspdf": "^2.5.1",
+    "localforage": "^1.10.0",
     "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^4.3.136",
-    "jspdf": "^2.5.1",
-    "tesseract.js": "^4.1.1",
-    "localforage": "^1.10.0",
-    "size-limit": "^11.0.0",
-    "@size-limit/file": "^11.0.0"
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tesseract.js": "^4.1.4"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
+    "@size-limit/file": "^11.2.0",
+    "size-limit": "^11.2.0",
+    "gzip-size": "^7.0.0",
+    "globby": "^11.1.0",
+    "@playwright/test": "^1.41.2",
+    "@types/jspdf": "^2.0.0",
+    "@types/node": "^20.8.4",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
-    "@types/node": "^20.8.4",
-    "eslint": "^8.50.0",
-    "@typescript-eslint/parser": "^6.7.5",
     "@typescript-eslint/eslint-plugin": "^6.7.5",
+    "@typescript-eslint/parser": "^6.7.5",
+    "@vitejs/plugin-react": "^4.0.0",
+    "eslint": "^8.50.0",
     "eslint-config-prettier": "^9.0.0",
     "prettier": "^3.0.3",
-    "vite": "^5.0.0",
-    "@vitejs/plugin-react": "^4.0.0",
-    "vite-tsconfig-paths": "^4.0.5",
-    "@playwright/test": "^1.41.2",
     "rollup-plugin-visualizer": "^5.12.0",
-    "@types/jspdf": "^2.0.0"
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0",
+    "vite-tsconfig-paths": "^4.0.5"
   },
   "engines": {
     "node": ">=18.18"
@@ -51,6 +53,9 @@
     "rollup-plugin-visualizer": "./scripts/rollup-plugin-visualizer.js"
   },
   "size-limit": [
-    { "path": "dist/assets/*.js", "limit": "40 KB" }
+    {
+      "path": "dist/assets/*.js",
+      "limit": "40 KB"
+    }
   ]
 }

--- a/scripts/size-guard.mjs
+++ b/scripts/size-guard.mjs
@@ -1,0 +1,41 @@
+import { createGzip } from 'zlib';
+import { promises as fs } from 'fs';
+import { globby } from 'globby';
+import path from 'path';
+
+const MAIN_LIMIT = 40 * 1024; // 40 KB gz
+const ROUTE_LIMIT = 1024;     // 1 KB gz
+
+async function gzSize(buf){
+  return await new Promise((res, rej)=>{
+    const gz = createGzip(); let out = 0;
+    gz.on('data', c => out += c.length);
+    gz.on('end', () => res(out));
+    gz.on('error', rej);
+    gz.end(buf);
+  });
+}
+
+const files = await globby('dist/assets/*.js');
+if (!files.length) { console.error('No built assets. Run `npm run build` first.'); process.exit(2); }
+
+let mainGz = 0, largestRoute = 0, bad = [];
+
+for (const f of files){
+  const base = path.basename(f);
+  const buf = await fs.readFile(f);
+  const gz = await gzSize(buf);
+  const isMain = /index-|main-|entry-/.test(base);
+  if (isMain) {
+    mainGz += gz;
+  } else {
+    largestRoute = Math.max(largestRoute, gz);
+    if (gz > ROUTE_LIMIT) bad.push(`${base} route gz ${gz}B > ${ROUTE_LIMIT}B`);
+  }
+}
+
+if (mainGz > MAIN_LIMIT) bad.push(`main gz ${mainGz}B > ${MAIN_LIMIT}B`);
+
+console.log(`main gz: ${mainGz}B; largest route gz: ${largestRoute}B`);
+if (bad.length){ console.error('Size guard failed:\n' + bad.join('\n')); process.exit(1); }
+console.log('Size guard OK');

--- a/src/app/components/ResultDownloadCard.tsx
+++ b/src/app/components/ResultDownloadCard.tsx
@@ -11,6 +11,7 @@ type Props = {
 
 export default function ResultDownloadCard({ srcName, srcSize, outName, outBlob, meta, onReset }: Props) {
   const outSize = outBlob.size;
+  const deltaPct = srcSize != null ? ((outSize - srcSize) / srcSize) * 100 : null;
   const badges: string[] = [];
   if (meta?.pipeline !== 'rasterAll') {
     badges.push('ATS-safe', 'Searchable');
@@ -18,6 +19,8 @@ export default function ResultDownloadCard({ srcName, srcSize, outName, outBlob,
   if (meta?.pipeline !== 'losslessClean') {
     badges.push('Lossy');
   }
+  if (meta?.ocr === 'tesseract.js') badges.push('OCR: tesseract.js');
+  if (meta?.ocr === 'stub') badges.push('OCR offline (stub)');
   const hint = srcSize != null && outSize > srcSize
     ? 'This preset kept vector text or metadata; try Smart or lower DPI/quality.'
     : null;
@@ -37,6 +40,9 @@ export default function ResultDownloadCard({ srcName, srcSize, outName, outBlob,
       <div className="mono" style={{ display: "grid", gap: 4 }}>
         <div>Source file: <strong>{srcName}</strong>{srcSize!=null ? ` - ${formatBytes(srcSize)}` : ""}</div>
         <div>Output file: <strong>{outName}</strong> - {formatBytes(outSize)}</div>
+        {deltaPct!=null && (
+          <div>Δ {deltaPct>0?'+':''}{deltaPct.toFixed(1)}%</div>
+        )}
       </div>
       {badges.length > 0 && (
         <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' }}>

--- a/src/app/routes/cv/Compress.tsx
+++ b/src/app/routes/cv/Compress.tsx
@@ -40,7 +40,7 @@ export default function CompressPage() {
 
   return (
     <div className="container">
-      <h2>Compress</h2>
+      <h2>Compress <a href="/cv/samples" className="text-sm underline" style={{marginLeft:8}}>Samples</a></h2>
       <div style={{ marginBottom: 8 }}>
         {[
           { id: "SMART", label: "Smart" },

--- a/src/app/routes/cv/Samples.tsx
+++ b/src/app/routes/cv/Samples.tsx
@@ -1,0 +1,29 @@
+import { jsPDF } from 'jspdf';
+import React from 'react';
+
+export default function Samples(){
+  async function makeTextOnly(){
+    const doc = new jsPDF(); doc.setFontSize(12);
+    for(let p=0;p<3;p++){ if(p) doc.addPage(); for(let i=0;i<40;i++) doc.text(`Line ${i+1} — Lorem ipsum dolor sit amet.`, 20, 20 + i*12); }
+    return new Blob([doc.output('arraybuffer')], { type:'application/pdf' });
+  }
+  async function makeImageHeavy(){
+    const doc = new jsPDF(); const img = await fetch('https://picsum.photos/1200/1600').then(r=>r.blob());
+    const dataUrl = await new Promise<string>(res => { const fr = new FileReader(); fr.onload=()=>res(fr.result as string); fr.readAsDataURL(img); });
+    for(let p=0;p<3;p++){ if(p) doc.addPage(); doc.addImage(dataUrl, 'JPEG', 0, 0, 595, 842); }
+    return new Blob([doc.output('arraybuffer')], { type:'application/pdf' });
+  }
+
+  async function download(name: string, blob: Blob){
+    const a = document.createElement('a'); a.href = URL.createObjectURL(blob); a.download = name; a.click(); setTimeout(()=>URL.revokeObjectURL(a.href), 1000);
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Sample PDFs</h1>
+      <button onClick={async()=>download('text-only.pdf', await makeTextOnly())} className="btn">Generate text-only</button>
+      <button onClick={async()=>download('image-heavy.pdf', await makeImageHeavy())} className="btn">Generate image-heavy</button>
+      <p className="text-sm opacity-70">Use these to measure Compress presets (Smart, ATS-safe, Email&lt;2MB, Smallest).</p>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ const routes: Record<string, () => Promise<{ default: React.ComponentType<any> }
   "/cv/jd-match": () => import("@/app/routes/cv/JdMatch"),
   "/cv/font-check": () => import("@/app/routes/cv/FontCheck"),
   "/cv/metadata-scrub": () => import("@/app/routes/cv/MetadataScrub"),
+  "/cv/samples": () => import("@/app/routes/cv/Samples"),
   "/why-ats": () => import("@/app/routes/WhyAts"),
   "/privacy": () => import("@/app/routes/Privacy"),
   "/security": () => import("@/app/routes/Security"),

--- a/src/pdf/workers/smartCompress.worker.ts
+++ b/src/pdf/workers/smartCompress.worker.ts
@@ -2,7 +2,7 @@ import { classifyDoc } from '../utils/classifyDoc';
 import { supportsWebP } from '../utils/detectWebP';
 import { iterateForTarget, BuildCfg } from '../utils/iterateForTarget';
 import { rasterAll } from '../pipelines/rasterAll';
-import { searchableImage } from '../pipelines/searchableImage';
+import { searchableImage, getOcrEngine } from '../pipelines/searchableImage';
 import { losslessClean } from '../pipelines/losslessClean';
 
 type Preset = 'smart'|'ats_safe'|'email_2mb'|'smallest';
@@ -40,7 +40,8 @@ self.onmessage = async (e: MessageEvent<Msg>) => {
       : (preset==='ats_safe' && kind==='TEXT_HEAVY') ? 'losslessClean'
       : (kind==='TEXT_HEAVY' ? 'losslessClean' : 'searchableImage');
 
-    self.postMessage({ type:'ok', blob: out.blob, meta:{ cfg: out.cfg, preset, kind, pipeline } }, undefined as any);
+    const ocr = getOcrEngine();
+    self.postMessage({ type:'ok', blob: out.blob, meta:{ cfg: out.cfg, preset, kind, pipeline, ocr } }, undefined as any);
   } catch (err) {
     self.postMessage({ type:'error', message: String(err) });
   }


### PR DESCRIPTION
## Summary
- dynamically import real tesseract.js OCR with stub fallback and report engine
- add gzip-based size guard script with size-limit fallback
- add sample PDF generator route and surface compression deltas/badges

## Testing
- `npm run build`
- `npm run size` *(fails: Package size limit has exceeded; size-guard import error)*

------
https://chatgpt.com/codex/tasks/task_e_689fe4881754832fa3df3fe82b82706b