### PR TITLE
fix(pdfjs): configure GlobalWorkerOptions worker via ?worker import and ensure it in all pdfjs code paths

### DIFF
--- a/src/pdf/pipelines/rasterAll.ts
+++ b/src/pdf/pipelines/rasterAll.ts
@@ -1,9 +1,11 @@
 import { jsPDF } from 'jspdf';
 import { renderPageBlob } from '../utils/pdfCanvas';
+import { ensurePdfWorker } from '../utils/ensurePdfWorker';
 
 export type RasterCfg = { dpi:number; quality:number; format:'jpeg'|'webp'; onProgress?:(p:any)=>void };
 
 export async function rasterAll(data:ArrayBuffer, cfg:RasterCfg): Promise<Blob> {
+  await ensurePdfWorker();
   const { getDocument } = await import('pdfjs-dist');
   const pdf = await getDocument({ data }).promise;
   let out: jsPDF | null = null;
@@ -21,6 +23,6 @@ export async function rasterAll(data:ArrayBuffer, cfg:RasterCfg): Promise<Blob> 
   return out!.output('blob');
 }
 
-function blobToDataURL(b:Blob){ 
+function blobToDataURL(b:Blob){
   return new Promise<string>(res => { const r=new FileReader(); r.onload=()=>res(r.result as string); r.readAsDataURL(b); });
 }

--- a/src/pdf/pipelines/searchableImage.ts
+++ b/src/pdf/pipelines/searchableImage.ts
@@ -1,5 +1,6 @@
 import { jsPDF } from 'jspdf';
 import { renderPageBlob } from '../utils/pdfCanvas';
+import { ensurePdfWorker } from '../utils/ensurePdfWorker';
 
 type Cfg = { dpi:number; quality:number; format:'jpeg'|'webp'; lang?:string; onProgress?:(p:any)=>void };
 
@@ -26,6 +27,7 @@ export function getOcrEngine(){ return ocrEngine; }
 
 export async function searchableImage(data:ArrayBuffer, cfg:Cfg): Promise<Blob> {
   ocrEngine = null;
+  await ensurePdfWorker();
   const { getDocument } = await import('pdfjs-dist');
   const pdf = await getDocument({ data }).promise;
   const doc = new jsPDF({ unit:'pt', compress:true });

--- a/src/pdf/utils/classifyDoc.ts
+++ b/src/pdf/utils/classifyDoc.ts
@@ -1,6 +1,8 @@
 import { getDocument } from 'pdfjs-dist';
+import { ensurePdfWorker } from './ensurePdfWorker';
 
 export async function classifyDoc(ab: ArrayBuffer, pagesToProbe = 2) {
+  await ensurePdfWorker();
   const pdf = await getDocument({ data: ab }).promise;
   let textGlyphs = 0, items = 0;
   const probe = Math.min(pdf.numPages, pagesToProbe);

--- a/src/pdf/utils/ensurePdfWorker.ts
+++ b/src/pdf/utils/ensurePdfWorker.ts
@@ -1,0 +1,30 @@
+let ready = false;
+
+/**
+ * Ensures pdfjs-dist has a worker configured.
+ * Prefer workerPort with ?worker import; fall back to another path.
+ */
+export async function ensurePdfWorker() {
+  if (ready) return;
+  const pdf = await import('pdfjs-dist'); // { GlobalWorkerOptions }
+  const { GlobalWorkerOptions } = pdf as any;
+
+  try {
+    // ESM worker (pdfjs v3)
+    const workerUrl = (await import('pdfjs-dist/build/pdf.worker.min.mjs?worker&url')).default as string;
+    GlobalWorkerOptions.workerPort = new Worker(workerUrl, { type: 'module' });
+    ready = true;
+    return;
+  } catch (_) { /* continue */ }
+
+  try {
+    // Legacy fallback
+    const workerUrl = (await import('pdfjs-dist/legacy/build/pdf.worker.min.mjs?worker&url')).default as string;
+    GlobalWorkerOptions.workerPort = new Worker(workerUrl, { type: 'module' });
+    ready = true;
+    return;
+  } catch (e) {
+    // Last resort: throw a clear error
+    throw new Error('Failed to load pdfjs worker. Ensure pdfjs-dist is installed.');
+  }
+}

--- a/src/pdf/utils/pdfCanvas.ts
+++ b/src/pdf/utils/pdfCanvas.ts
@@ -1,24 +1,43 @@
 import { getDocument } from 'pdfjs-dist';
+import { ensurePdfWorker } from './ensurePdfWorker';
 
 export type RenderOpts = {
   data: ArrayBuffer; page: number; dpi: number; format: 'jpeg'|'webp'; quality: number;
 };
 
 export async function renderPageBlob(opts: RenderOpts): Promise<{blob:Blob; width:number; height:number}> {
+  await ensurePdfWorker();
   const pdf = await getDocument({ data: opts.data }).promise;
   const page = await pdf.getPage(opts.page);
   const vp = page.getViewport({ scale: opts.dpi / 72 });
-  const canvas = new OffscreenCanvas(vp.width, vp.height);
+
+  // OffscreenCanvas when available, fallback to HTMLCanvas
+  const anySelf: any = (typeof self !== 'undefined') ? self : globalThis;
+  let canvas: any;
+  if (typeof anySelf.OffscreenCanvas !== 'undefined') {
+    canvas = new anySelf.OffscreenCanvas(vp.width, vp.height);
+  } else {
+    // @ts-ignore
+    const c = (anySelf.document || {}).createElement ? anySelf.document.createElement('canvas') : null;
+    if (!c) throw new Error('Canvas not available');
+    c.width = vp.width; c.height = vp.height;
+    canvas = c;
+  }
+
   const ctx = canvas.getContext('2d')!;
   await page.render({ canvasContext: ctx as any, viewport: vp }).promise;
+
   const type = opts.format === 'webp' ? 'image/webp' : 'image/jpeg';
-  const blob: Blob = (canvas as any).convertToBlob
-    ? await (canvas as any).convertToBlob({ type, quality: opts.quality })
-    : await new Promise(res => (canvas as any).toBlob(res, type, opts.quality));
+  const toBlob = (canvas as any).convertToBlob
+    ? (canvas as any).convertToBlob({ type, quality: opts.quality })
+    : new Promise<Blob>(res => (canvas as any).toBlob((b: Blob) => res(b!), type, opts.quality));
+
+  const blob: Blob = await toBlob;
   return { blob, width: vp.width, height: vp.height };
 }
 
 export async function textItemsForPage(data: ArrayBuffer, pageNo: number){
+  await ensurePdfWorker();
   const pdf = await getDocument({ data }).promise;
   const page = await pdf.getPage(pageNo);
   return page.getTextContent();

--- a/src/pdf/workers/exportText.worker.ts
+++ b/src/pdf/workers/exportText.worker.ts
@@ -1,10 +1,10 @@
-import { getDocument, GlobalWorkerOptions } from "pdfjs-dist";
+import { getDocument } from "pdfjs-dist";
 import type { ExportTextPayload } from "@/pdf/types";
-
-GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
+import { ensurePdfWorker } from "../utils/ensurePdfWorker";
 
 self.onmessage = async (e: MessageEvent<ExportTextPayload>) => {
   try {
+    await ensurePdfWorker();
     const loadingTask = getDocument({ data: e.data.file });
     const pdf = await loadingTask.promise;
     let text = "";

--- a/src/pdf/workers/fontCheck.worker.ts
+++ b/src/pdf/workers/fontCheck.worker.ts
@@ -1,13 +1,13 @@
-// @ts-ignore
-import * as pdfjs from "pdfjs-dist/legacy/build/pdf.mjs";
-(pdfjs as any).GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
+import { getDocument } from 'pdfjs-dist';
+import { ensurePdfWorker } from '../utils/ensurePdfWorker';
 const ATS_GOOD=["Arial","Calibri","Helvetica","Times New Roman","Times-Roman"];
 const ATS_RISK=["Garamond","Courier","Papyrus","Comic Sans","Symbol"];
 self.onmessage=async(e:MessageEvent<{file:ArrayBuffer;maxPages?:number}>)=>{
   const post=(m:any)=>(self as any).postMessage(m);
   try{
+    await ensurePdfWorker();
     const {file,maxPages=20}=e.data;
-    const pdf=(await pdfjs.getDocument({data:file}).promise);
+    const pdf=(await getDocument({data:file}).promise);
     const seen:Record<string,number>={}; const total=Math.min(pdf.numPages,maxPages);
     for(let i=1;i<=total;i++){
       const p=await pdf.getPage(i); const c=await p.getTextContent();


### PR DESCRIPTION
## Summary
- add `ensurePdfWorker` helper to set `GlobalWorkerOptions.workerPort` via `?worker` import with legacy fallback
- invoke `ensurePdfWorker` in all pdfjs code paths and add canvas fallback logic

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run size`


------
https://chatgpt.com/codex/tasks/task_e_68a0059e89a8832fbd9cfc3be475d1a5