### PR TITLE
chore(audit): replace raw pdfjs getDocument with safe helper; add safeStorage wrapper

### DIFF
--- a/scripts/codemod-pdf-getdoc.mjs
+++ b/scripts/codemod-pdf-getdoc.mjs
@@ -1,0 +1,28 @@
+import fs from 'fs'; import path from 'path';
+const SRC='src';
+const files=[];
+(function walk(d){ for (const f of fs.readdirSync(d)) {
+  const p=path.join(d,f); const s=fs.statSync(p);
+  if (s.isDirectory()) { if(!['node_modules','.git','dist','coverage'].includes(f)) walk(p); }
+  else if (/\.(ts|tsx|js)$/.test(f)) files.push(p);
+}})(SRC);
+
+let changed=0, hits=[];
+for (const p of files){
+  let t=fs.readFileSync(p,'utf8'); const before=t;
+  // find getDocument({ data: ... }).promise
+  t=t.replace(/getDocument\s*\(\s*\{\s*data\s*:\s*([^}]+)\}\s*\)\s*\.promise/g,
+              (_m, g1)=>`getPdfFromData(${g1.trim()})`);
+  t=t.replace(/getDocument\s*\(\s*\{\s*data\s*\}\s*\)\s*\.promise/g,
+              'getPdfFromData(data)');
+  if (t!==before){
+    // add import if not present
+    if (!/getPdfFromData\s*\(/.test(before) || !/from\s+['"]\.{0,2}\/[^'"]*safePdf['"]/.test(before)){
+      const importLine = `import { getPdfFromData } from '@/pdf/utils/safePdf';\n`;
+      if (!/^import .*getPdfFromData/m.test(t)) t = importLine + t;
+    }
+    fs.writeFileSync(p,t); changed++; hits.push(p);
+  }
+}
+console.log(`codemod: replaced raw getDocument in ${changed} file(s)`);
+hits.forEach(h=>console.log(' -',h));

--- a/src/pdf/pipelines/rasterAll.ts
+++ b/src/pdf/pipelines/rasterAll.ts
@@ -1,3 +1,4 @@
+import { getPdfFromData } from '../utils/safePdf';
 import { jsPDF } from 'jspdf';
 import { renderPageBlob } from '../utils/pdfCanvas';
 import { ensurePdfWorker } from '../utils/ensurePdfWorker';
@@ -6,8 +7,7 @@ export type RasterCfg = { dpi:number; quality:number; format:'jpeg'|'webp'; onPr
 
 export async function rasterAll(data:ArrayBuffer, cfg:RasterCfg): Promise<Blob> {
   await ensurePdfWorker();
-  const { getDocument } = await import('pdfjs-dist');
-  const pdf = await getDocument({ data }).promise;
+  const pdf = await getPdfFromData(data);
   let out: jsPDF | null = null;
 
   for (let p=1;p<=pdf.numPages;p++){

--- a/src/pdf/pipelines/searchableImage.ts
+++ b/src/pdf/pipelines/searchableImage.ts
@@ -1,3 +1,4 @@
+import { getPdfFromData } from '../utils/safePdf';
 import { jsPDF } from 'jspdf';
 import { renderPageBlob } from '../utils/pdfCanvas';
 import { ensurePdfWorker } from '../utils/ensurePdfWorker';
@@ -28,8 +29,7 @@ export function getOcrEngine(){ return ocrEngine; }
 export async function searchableImage(data:ArrayBuffer, cfg:Cfg): Promise<Blob> {
   ocrEngine = null;
   await ensurePdfWorker();
-  const { getDocument } = await import('pdfjs-dist');
-  const pdf = await getDocument({ data }).promise;
+  const pdf = await getPdfFromData(data);
   const doc = new jsPDF({ unit:'pt', compress:true });
 
   for (let p=1;p<=pdf.numPages;p++){

--- a/src/pdf/utils/classifyDoc.ts
+++ b/src/pdf/utils/classifyDoc.ts
@@ -1,9 +1,9 @@
-import { getDocument } from 'pdfjs-dist';
+import { getPdfFromData } from './safePdf';
 import { ensurePdfWorker } from './ensurePdfWorker';
 
 export async function classifyDoc(ab: ArrayBuffer, pagesToProbe = 2) {
   await ensurePdfWorker();
-  const pdf = await getDocument({ data: ab }).promise;
+  const pdf = await getPdfFromData(ab);
   let textGlyphs = 0, items = 0;
   const probe = Math.min(pdf.numPages, pagesToProbe);
   for (let p = 1; p <= probe; p++) {

--- a/src/pdf/utils/pdfCanvas.ts
+++ b/src/pdf/utils/pdfCanvas.ts
@@ -1,4 +1,4 @@
-import { getDocument } from 'pdfjs-dist';
+import { getPdfFromData } from './safePdf';
 import { ensurePdfWorker } from './ensurePdfWorker';
 
 export type RenderOpts = {
@@ -7,7 +7,7 @@ export type RenderOpts = {
 
 export async function renderPageBlob(opts: RenderOpts): Promise<{blob:Blob; width:number; height:number}> {
   await ensurePdfWorker();
-  const pdf = await getDocument({ data: opts.data }).promise;
+  const pdf = await getPdfFromData(opts.data);
   const page = await pdf.getPage(opts.page);
   const vp = page.getViewport({ scale: opts.dpi / 72 });
 
@@ -38,7 +38,7 @@ export async function renderPageBlob(opts: RenderOpts): Promise<{blob:Blob; widt
 
 export async function textItemsForPage(data: ArrayBuffer, pageNo: number){
   await ensurePdfWorker();
-  const pdf = await getDocument({ data }).promise;
+  const pdf = await getPdfFromData(data);
   const page = await pdf.getPage(pageNo);
   return page.getTextContent();
 }

--- a/src/pdf/utils/safePdf.ts
+++ b/src/pdf/utils/safePdf.ts
@@ -1,0 +1,8 @@
+import { ensurePdfWorker } from './ensurePdfWorker';
+
+/** Open a pdfjs document safely from a buffer (clones to avoid detaching caller). */
+export async function getPdfFromData(data: ArrayBuffer) {
+  await ensurePdfWorker();
+  const { getDocument } = await import('pdfjs-dist');
+  return getDocument({ data: data.slice(0) }).promise;
+}

--- a/src/pdf/workers/exportText.worker.ts
+++ b/src/pdf/workers/exportText.worker.ts
@@ -1,12 +1,9 @@
-import { getDocument } from "pdfjs-dist";
+import { getPdfFromData } from "../utils/safePdf";
 import type { ExportTextPayload } from "@/pdf/types";
-import { ensurePdfWorker } from "../utils/ensurePdfWorker";
 
 self.onmessage = async (e: MessageEvent<ExportTextPayload>) => {
   try {
-    await ensurePdfWorker();
-    const loadingTask = getDocument({ data: e.data.file });
-    const pdf = await loadingTask.promise;
+    const pdf = await getPdfFromData(e.data.file);
     let text = "";
     for (let i = 1; i <= pdf.numPages; i++) {
       const page = await pdf.getPage(i);

--- a/src/pdf/workers/fontCheck.worker.ts
+++ b/src/pdf/workers/fontCheck.worker.ts
@@ -1,4 +1,4 @@
-import { getDocument } from 'pdfjs-dist';
+import { getPdfFromData } from '../utils/safePdf';
 import { ensurePdfWorker } from '../utils/ensurePdfWorker';
 const ATS_GOOD=["Arial","Calibri","Helvetica","Times New Roman","Times-Roman"];
 const ATS_RISK=["Garamond","Courier","Papyrus","Comic Sans","Symbol"];
@@ -7,7 +7,7 @@ self.onmessage=async(e:MessageEvent<{file:ArrayBuffer;maxPages?:number}>)=>{
   try{
     await ensurePdfWorker();
     const {file,maxPages=20}=e.data;
-    const pdf=(await getDocument({data:file}).promise);
+    const pdf=(await getPdfFromData(file));
     const seen:Record<string,number>={}; const total=Math.min(pdf.numPages,maxPages);
     for(let i=1;i<=total;i++){
       const p=await pdf.getPage(i); const c=await p.getTextContent();

--- a/src/pro/gating.ts
+++ b/src/pro/gating.ts
@@ -1,7 +1,8 @@
+import { storage } from '@/utils/safeStorage';
 const KEY="atscv:quota:v1"; type Quota={ocr:number;jd:number;day:string;pro?:boolean};
 const today=()=>new Date().toISOString().slice(0,10);
-export const isPro=()=>JSON.parse(localStorage.getItem(KEY)||"{}").pro===true;
-function read():Quota{const raw=JSON.parse(localStorage.getItem(KEY)||"{}");if(raw.day!==today()){const n:{ocr:number;jd:number;day:string;pro?:boolean}={ocr:0,jd:0,day:today(),pro:raw.pro};localStorage.setItem(KEY,JSON.stringify(n));return n;}return raw;}
+export const isPro=()=>JSON.parse(storage.get(KEY)||"{}").pro===true;
+function read():Quota{const raw=JSON.parse(storage.get(KEY)||"{}");if(raw.day!==today()){const n:{ocr:number;jd:number;day:string;pro?:boolean}={ocr:0,jd:0,day:today(),pro:raw.pro};storage.set(KEY,JSON.stringify(n));return n;}return raw;}
 export function canUse(f:"ocr"|"jd"){const limit={ocr:1,jd:1};const q=read();return isPro()||(q[f]??0)<limit[f];}
-export function consume(f:"ocr"|"jd"){if(isPro())return;const q=read();localStorage.setItem(KEY,JSON.stringify({...q,[f]:(q[f]??0)+1}));}
-export function redeem(code:string){if(code.trim().toUpperCase()===(import.meta.env.VITE_PRO_CODE||"ALPHA-ATS-2025")){const q=read();localStorage.setItem(KEY,JSON.stringify({...q,pro:true}));return true;}return false;}
+export function consume(f:"ocr"|"jd"){if(isPro())return;const q=read();storage.set(KEY,JSON.stringify({...q,[f]:(q[f]??0)+1}));}
+export function redeem(code:string){if(code.trim().toUpperCase()===(import.meta.env.VITE_PRO_CODE||"ALPHA-ATS-2025")){const q=read();storage.set(KEY,JSON.stringify({...q,pro:true}));return true;}return false;}

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -1,0 +1,11 @@
+export const storage = {
+  get(k: string) {
+    try { return window.localStorage.getItem(k); } catch { return null; }
+  },
+  set(k: string, v: string) {
+    try { window.localStorage.setItem(k, v); } catch {}
+  },
+  remove(k: string) {
+    try { window.localStorage.removeItem(k); } catch {}
+  }
+};


### PR DESCRIPTION
## Summary
- add safe helper that clones PDF buffers and ensures worker before loading
- guard localStorage access via new safeStorage wrapper
- codemod to swap raw pdfjs getDocument calls with safer helper

## Testing
- `npm run build`
- `npm run size`
- `npm run audit` *(fails: Missing script "audit")*
- `npm audit` *(fails: ENOLOCK audit requires existing lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a041b5fbf4832fb9051e6128bf2393