### PR TITLE
chore(audit): add resilient npm audit script

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,10 +1,35 @@
-# npm audit report
+# Dependency Audit
 
-## Summary
-- critical: 0
-- high: 0
-- moderate: 0
-- low: 0
-- info: 0
+- Timestamp: 2025-08-16T10:59:44.832Z
+- Registry: https://registry.npmjs.org/
 
-Generated on 2025-08-16T09:05:00.431Z
+## Status
+- ❗ Audit API unreachable – audit incomplete.
+
+## Installed top-level packages
+- @playwright/test@1.54.2
+- @types/jspdf@2.0.0
+- @types/node@20.19.11
+- @types/react-dom@18.3.7
+- @types/react@18.3.23
+- @typescript-eslint/eslint-plugin@6.21.0
+- @typescript-eslint/parser@6.21.0
+- @vitejs/plugin-react@4.7.0
+- eslint-config-prettier@9.1.2
+- eslint@8.57.1
+- jspdf@2.5.2
+- localforage@1.10.0
+- pdf-lib@1.17.1
+- pdfjs-dist@4.10.38
+- prettier@3.6.2
+- react-dom@18.2.0
+- react@18.2.0
+- rollup-plugin-visualizer@5.14.0
+- tesseract.js@4.1.4
+- typescript@5.9.2
+- vite-tsconfig-paths@4.3.2
+- vite@5.4.19
+
+## Action
+- Re-run with a working network or different registry.
+- Example: `NPM_REGISTRY=https://registry.npmjs.org/ npm run audit`

--- a/audit-report.json
+++ b/audit-report.json
@@ -1,0 +1,668 @@
+{
+  "error": "Error: Command failed: npm audit --json --registry=https://registry.npmjs.org/\nnpm warn Unknown env config \"http-proxy\". This will stop working in the next major version of npm.\nnpm warn audit 403 Forbidden - POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk\nnpm error audit endpoint returned an error\nnpm error A complete log of this run can be found in: /root/.npm/_logs/2025-08-16T10_59_43_488Z-debug-0.log\n",
+  "ls": {
+    "version": "1.0.0",
+    "name": "pdf-tool-site",
+    "private": true,
+    "scripts": {
+      "dev": "vite",
+      "build": "vite build",
+      "preview": "vite preview",
+      "lint": "eslint . --ext .ts,.tsx --max-warnings=0",
+      "typecheck": "tsc -p tsconfig.json --noEmit",
+      "ascii:fix": "node scripts/ascii-fix.mjs",
+      "ascii:check": "rg -n \"[^\\x00-\\x7F]\" src && (echo 'Non-ASCII found' && exit 1) || echo 'ASCII OK'",
+      "build:stats": "vite build && echo 'Open dist/stats.html' || true",
+      "test:smoke": "SMOKE_MODE=lite playwright test -c playwright.config.ts",
+      "test:smoke:full": "playwright test",
+      "postinstall": "playwright install --with-deps || true",
+      "size": "node scripts/size-guard.mjs",
+      "audit": "node scripts/audit.mjs"
+    },
+    "devDependencies": {
+      "@playwright/test": "^1.41.2",
+      "@types/jspdf": "^2.0.0",
+      "@types/node": "^20.8.4",
+      "@types/react": "^18.2.37",
+      "@types/react-dom": "^18.2.15",
+      "@typescript-eslint/eslint-plugin": "^6.7.5",
+      "@typescript-eslint/parser": "^6.7.5",
+      "@vitejs/plugin-react": "^4.0.0",
+      "eslint": "^8.50.0",
+      "eslint-config-prettier": "^9.0.0",
+      "prettier": "^3.0.3",
+      "rollup-plugin-visualizer": "^5.12.0",
+      "typescript": "^5.2.2",
+      "vite": "^5.0.0",
+      "vite-tsconfig-paths": "^4.0.5"
+    },
+    "engines": {
+      "node": ">=18.18"
+    },
+    "imports": {
+      "rollup-plugin-visualizer": "./scripts/rollup-plugin-visualizer.js"
+    },
+    "_id": "pdf-tool-site@1.0.0",
+    "extraneous": false,
+    "path": "/workspace/pdf-tool-site",
+    "_dependencies": {
+      "jspdf": "^2.5.1",
+      "localforage": "^1.10.0",
+      "pdf-lib": "^1.17.1",
+      "pdfjs-dist": "^4.3.136",
+      "react": "18.2.0",
+      "react-dom": "18.2.0",
+      "tesseract.js": "^4.1.4"
+    },
+    "peerDependencies": {},
+    "dependencies": {
+      "@playwright/test": {
+        "version": "1.54.2",
+        "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+        "overridden": false,
+        "name": "@playwright/test",
+        "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+        "dev": true,
+        "license": "Apache-2.0",
+        "bin": {
+          "playwright": "cli.js"
+        },
+        "engines": {
+          "node": ">=18"
+        },
+        "_id": "@playwright/test@1.54.2",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/@playwright/test",
+        "_dependencies": {
+          "playwright": "1.54.2"
+        },
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "@types/jspdf": {
+        "version": "2.0.0",
+        "resolved": "https://registry.npmjs.org/@types/jspdf/-/jspdf-2.0.0.tgz",
+        "overridden": false,
+        "name": "@types/jspdf",
+        "integrity": "sha512-oonYDXI4GegGaG7FFVtriJ+Yqlh4YR3L3NVDiwCEBVG7sbya19SoGx4MW4kg1MCMRPgkbbFTck8YKJL8PrkDfA==",
+        "deprecated": "This is a stub types definition. jspdf provides its own type definitions, so you do not need this installed.",
+        "dev": true,
+        "license": "MIT",
+        "_id": "@types/jspdf@2.0.0",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/@types/jspdf",
+        "_dependencies": {
+          "jspdf": "*"
+        },
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "@types/node": {
+        "version": "20.19.11",
+        "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+        "overridden": false,
+        "name": "@types/node",
+        "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+        "dev": true,
+        "license": "MIT",
+        "_id": "@types/node@20.19.11",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/@types/node",
+        "_dependencies": {
+          "undici-types": "~6.21.0"
+        },
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "@types/react-dom": {
+        "version": "18.3.7",
+        "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+        "overridden": false,
+        "name": "@types/react-dom",
+        "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+        "dev": true,
+        "license": "MIT",
+        "peerDependencies": {
+          "@types/react": "^18.0.0"
+        },
+        "_id": "@types/react-dom@18.3.7",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/@types/react-dom",
+        "_dependencies": {},
+        "devDependencies": {}
+      },
+      "@types/react": {
+        "version": "18.3.23",
+        "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+        "overridden": false,
+        "name": "@types/react",
+        "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+        "dev": true,
+        "license": "MIT",
+        "_id": "@types/react@18.3.23",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/@types/react",
+        "_dependencies": {
+          "@types/prop-types": "*",
+          "csstype": "^3.0.2"
+        },
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "@typescript-eslint/eslint-plugin": {
+        "version": "6.21.0",
+        "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+        "overridden": false,
+        "name": "@typescript-eslint/eslint-plugin",
+        "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+        "dev": true,
+        "license": "MIT",
+        "engines": {
+          "node": "^16.0.0 || >=18.0.0"
+        },
+        "funding": {
+          "type": "opencollective",
+          "url": "https://opencollective.com/typescript-eslint"
+        },
+        "peerDependencies": {
+          "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+          "eslint": "^7.0.0 || ^8.0.0"
+        },
+        "peerDependenciesMeta": {
+          "typescript": {
+            "optional": true
+          }
+        },
+        "_id": "@typescript-eslint/eslint-plugin@6.21.0",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/@typescript-eslint/eslint-plugin",
+        "_dependencies": {
+          "@eslint-community/regexpp": "^4.5.1",
+          "@typescript-eslint/scope-manager": "6.21.0",
+          "@typescript-eslint/type-utils": "6.21.0",
+          "@typescript-eslint/utils": "6.21.0",
+          "@typescript-eslint/visitor-keys": "6.21.0",
+          "debug": "^4.3.4",
+          "graphemer": "^1.4.0",
+          "ignore": "^5.2.4",
+          "natural-compare": "^1.4.0",
+          "semver": "^7.5.4",
+          "ts-api-utils": "^1.0.1"
+        },
+        "devDependencies": {}
+      },
+      "@typescript-eslint/parser": {
+        "version": "6.21.0",
+        "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+        "overridden": false,
+        "name": "@typescript-eslint/parser",
+        "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+        "dev": true,
+        "license": "BSD-2-Clause",
+        "engines": {
+          "node": "^16.0.0 || >=18.0.0"
+        },
+        "funding": {
+          "type": "opencollective",
+          "url": "https://opencollective.com/typescript-eslint"
+        },
+        "peerDependencies": {
+          "eslint": "^7.0.0 || ^8.0.0"
+        },
+        "peerDependenciesMeta": {
+          "typescript": {
+            "optional": true
+          }
+        },
+        "_id": "@typescript-eslint/parser@6.21.0",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/@typescript-eslint/parser",
+        "_dependencies": {
+          "@typescript-eslint/scope-manager": "6.21.0",
+          "@typescript-eslint/types": "6.21.0",
+          "@typescript-eslint/typescript-estree": "6.21.0",
+          "@typescript-eslint/visitor-keys": "6.21.0",
+          "debug": "^4.3.4"
+        },
+        "devDependencies": {}
+      },
+      "@vitejs/plugin-react": {
+        "version": "4.7.0",
+        "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+        "overridden": false,
+        "name": "@vitejs/plugin-react",
+        "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+        "dev": true,
+        "license": "MIT",
+        "engines": {
+          "node": "^14.18.0 || >=16.0.0"
+        },
+        "peerDependencies": {
+          "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        },
+        "_id": "@vitejs/plugin-react@4.7.0",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/@vitejs/plugin-react",
+        "_dependencies": {
+          "@babel/core": "^7.28.0",
+          "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+          "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+          "@rolldown/pluginutils": "1.0.0-beta.27",
+          "@types/babel__core": "^7.20.5",
+          "react-refresh": "^0.17.0"
+        },
+        "devDependencies": {}
+      },
+      "eslint-config-prettier": {
+        "version": "9.1.2",
+        "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+        "overridden": false,
+        "name": "eslint-config-prettier",
+        "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+        "dev": true,
+        "license": "MIT",
+        "bin": {
+          "eslint-config-prettier": "bin/cli.js"
+        },
+        "peerDependencies": {
+          "eslint": ">=7.0.0"
+        },
+        "_id": "eslint-config-prettier@9.1.2",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/eslint-config-prettier",
+        "_dependencies": {},
+        "devDependencies": {}
+      },
+      "eslint": {
+        "version": "8.57.1",
+        "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+        "overridden": false,
+        "name": "eslint",
+        "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+        "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+        "dev": true,
+        "license": "MIT",
+        "bin": {
+          "eslint": "bin/eslint.js"
+        },
+        "engines": {
+          "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        },
+        "funding": {
+          "url": "https://opencollective.com/eslint"
+        },
+        "_id": "eslint@8.57.1",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/eslint",
+        "_dependencies": {
+          "@eslint-community/eslint-utils": "^4.2.0",
+          "@eslint-community/regexpp": "^4.6.1",
+          "@eslint/eslintrc": "^2.1.4",
+          "@eslint/js": "8.57.1",
+          "@humanwhocodes/config-array": "^0.13.0",
+          "@humanwhocodes/module-importer": "^1.0.1",
+          "@nodelib/fs.walk": "^1.2.8",
+          "@ungap/structured-clone": "^1.2.0",
+          "ajv": "^6.12.4",
+          "chalk": "^4.0.0",
+          "cross-spawn": "^7.0.2",
+          "debug": "^4.3.2",
+          "doctrine": "^3.0.0",
+          "escape-string-regexp": "^4.0.0",
+          "eslint-scope": "^7.2.2",
+          "eslint-visitor-keys": "^3.4.3",
+          "espree": "^9.6.1",
+          "esquery": "^1.4.2",
+          "esutils": "^2.0.2",
+          "fast-deep-equal": "^3.1.3",
+          "file-entry-cache": "^6.0.1",
+          "find-up": "^5.0.0",
+          "glob-parent": "^6.0.2",
+          "globals": "^13.19.0",
+          "graphemer": "^1.4.0",
+          "ignore": "^5.2.0",
+          "imurmurhash": "^0.1.4",
+          "is-glob": "^4.0.0",
+          "is-path-inside": "^3.0.3",
+          "js-yaml": "^4.1.0",
+          "json-stable-stringify-without-jsonify": "^1.0.1",
+          "levn": "^0.4.1",
+          "lodash.merge": "^4.6.2",
+          "minimatch": "^3.1.2",
+          "natural-compare": "^1.4.0",
+          "optionator": "^0.9.3",
+          "strip-ansi": "^6.0.1",
+          "text-table": "^0.2.0"
+        },
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "jspdf": {
+        "version": "2.5.2",
+        "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+        "overridden": false,
+        "name": "jspdf",
+        "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+        "license": "MIT",
+        "optionalDependencies": {
+          "canvg": "^3.0.6",
+          "core-js": "^3.6.0",
+          "dompurify": "^2.5.4",
+          "html2canvas": "^1.0.0-rc.5"
+        },
+        "_id": "jspdf@2.5.2",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/jspdf",
+        "_dependencies": {
+          "@babel/runtime": "^7.23.2",
+          "atob": "^2.1.2",
+          "btoa": "^1.2.1",
+          "fflate": "^0.8.1",
+          "canvg": "^3.0.6",
+          "core-js": "^3.6.0",
+          "dompurify": "^2.5.4",
+          "html2canvas": "^1.0.0-rc.5"
+        },
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "localforage": {
+        "version": "1.10.0",
+        "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+        "overridden": false,
+        "name": "localforage",
+        "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+        "license": "Apache-2.0",
+        "_id": "localforage@1.10.0",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/localforage",
+        "_dependencies": {
+          "lie": "3.1.1"
+        },
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "pdf-lib": {
+        "version": "1.17.1",
+        "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+        "overridden": false,
+        "name": "pdf-lib",
+        "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+        "license": "MIT",
+        "_id": "pdf-lib@1.17.1",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/pdf-lib",
+        "_dependencies": {
+          "@pdf-lib/standard-fonts": "^1.0.0",
+          "@pdf-lib/upng": "^1.0.1",
+          "pako": "^1.0.11",
+          "tslib": "^1.11.1"
+        },
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "pdfjs-dist": {
+        "version": "4.10.38",
+        "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+        "overridden": false,
+        "name": "pdfjs-dist",
+        "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+        "license": "Apache-2.0",
+        "engines": {
+          "node": ">=20"
+        },
+        "optionalDependencies": {
+          "@napi-rs/canvas": "^0.1.65"
+        },
+        "_id": "pdfjs-dist@4.10.38",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/pdfjs-dist",
+        "_dependencies": {
+          "@napi-rs/canvas": "^0.1.65"
+        },
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "prettier": {
+        "version": "3.6.2",
+        "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+        "overridden": false,
+        "name": "prettier",
+        "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+        "dev": true,
+        "license": "MIT",
+        "bin": {
+          "prettier": "bin/prettier.cjs"
+        },
+        "engines": {
+          "node": ">=14"
+        },
+        "funding": {
+          "url": "https://github.com/prettier/prettier?sponsor=1"
+        },
+        "_id": "prettier@3.6.2",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/prettier",
+        "_dependencies": {},
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "react-dom": {
+        "version": "18.2.0",
+        "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+        "overridden": false,
+        "name": "react-dom",
+        "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+        "license": "MIT",
+        "peerDependencies": {
+          "react": "^18.2.0"
+        },
+        "_id": "react-dom@18.2.0",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/react-dom",
+        "_dependencies": {
+          "loose-envify": "^1.1.0",
+          "scheduler": "^0.23.0"
+        },
+        "devDependencies": {}
+      },
+      "react": {
+        "version": "18.2.0",
+        "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+        "overridden": false,
+        "name": "react",
+        "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+        "license": "MIT",
+        "engines": {
+          "node": ">=0.10.0"
+        },
+        "_id": "react@18.2.0",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/react",
+        "_dependencies": {
+          "loose-envify": "^1.1.0"
+        },
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "rollup-plugin-visualizer": {
+        "version": "5.14.0",
+        "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz",
+        "overridden": false,
+        "name": "rollup-plugin-visualizer",
+        "integrity": "sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==",
+        "dev": true,
+        "license": "MIT",
+        "bin": {
+          "rollup-plugin-visualizer": "dist/bin/cli.js"
+        },
+        "engines": {
+          "node": ">=18"
+        },
+        "peerDependencies": {
+          "rolldown": "1.x",
+          "rollup": "2.x || 3.x || 4.x"
+        },
+        "peerDependenciesMeta": {
+          "rolldown": {
+            "optional": true
+          },
+          "rollup": {
+            "optional": true
+          }
+        },
+        "_id": "rollup-plugin-visualizer@5.14.0",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/rollup-plugin-visualizer",
+        "_dependencies": {
+          "open": "^8.4.0",
+          "picomatch": "^4.0.2",
+          "source-map": "^0.7.4",
+          "yargs": "^17.5.1"
+        },
+        "devDependencies": {}
+      },
+      "tesseract.js": {
+        "version": "4.1.4",
+        "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-4.1.4.tgz",
+        "overridden": false,
+        "name": "tesseract.js",
+        "integrity": "sha512-iLjJjLWVNV4PApofEsd54Y1MbjhzpPxEzF8EjYmC2CLN4hrUqO5aTNTSbGA7/QjycKtAWHhn2YmDR+6GFwi2Zg==",
+        "hasInstallScript": true,
+        "license": "Apache-2.0",
+        "_id": "tesseract.js@4.1.4",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/tesseract.js",
+        "_dependencies": {
+          "bmp-js": "^0.1.0",
+          "idb-keyval": "^6.2.0",
+          "is-electron": "^2.2.2",
+          "is-url": "^1.2.4",
+          "node-fetch": "^2.6.9",
+          "opencollective-postinstall": "^2.0.3",
+          "regenerator-runtime": "^0.13.3",
+          "tesseract.js-core": "^4.0.4",
+          "wasm-feature-detect": "^1.2.11",
+          "zlibjs": "^0.3.1"
+        },
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "typescript": {
+        "version": "5.9.2",
+        "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+        "overridden": false,
+        "name": "typescript",
+        "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+        "dev": true,
+        "license": "Apache-2.0",
+        "bin": {
+          "tsc": "bin/tsc",
+          "tsserver": "bin/tsserver"
+        },
+        "engines": {
+          "node": ">=14.17"
+        },
+        "_id": "typescript@5.9.2",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/typescript",
+        "_dependencies": {},
+        "devDependencies": {},
+        "peerDependencies": {}
+      },
+      "vite-tsconfig-paths": {
+        "version": "4.3.2",
+        "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz",
+        "overridden": false,
+        "name": "vite-tsconfig-paths",
+        "integrity": "sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==",
+        "dev": true,
+        "license": "MIT",
+        "peerDependencies": {
+          "vite": "*"
+        },
+        "peerDependenciesMeta": {
+          "vite": {
+            "optional": true
+          }
+        },
+        "_id": "vite-tsconfig-paths@4.3.2",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/vite-tsconfig-paths",
+        "_dependencies": {
+          "debug": "^4.1.1",
+          "globrex": "^0.1.2",
+          "tsconfck": "^3.0.3"
+        },
+        "devDependencies": {}
+      },
+      "vite": {
+        "version": "5.4.19",
+        "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+        "overridden": false,
+        "name": "vite",
+        "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+        "dev": true,
+        "license": "MIT",
+        "bin": {
+          "vite": "bin/vite.js"
+        },
+        "engines": {
+          "node": "^18.0.0 || >=20.0.0"
+        },
+        "funding": {
+          "url": "https://github.com/vitejs/vite?sponsor=1"
+        },
+        "optionalDependencies": {
+          "fsevents": "~2.3.3"
+        },
+        "peerDependencies": {
+          "@types/node": "^18.0.0 || >=20.0.0",
+          "less": "*",
+          "lightningcss": "^1.21.0",
+          "sass": "*",
+          "sass-embedded": "*",
+          "stylus": "*",
+          "sugarss": "*",
+          "terser": "^5.4.0"
+        },
+        "peerDependenciesMeta": {
+          "@types/node": {
+            "optional": true
+          },
+          "less": {
+            "optional": true
+          },
+          "lightningcss": {
+            "optional": true
+          },
+          "sass": {
+            "optional": true
+          },
+          "sass-embedded": {
+            "optional": true
+          },
+          "stylus": {
+            "optional": true
+          },
+          "sugarss": {
+            "optional": true
+          },
+          "terser": {
+            "optional": true
+          }
+        },
+        "_id": "vite@5.4.19",
+        "extraneous": false,
+        "path": "/workspace/pdf-tool-site/node_modules/vite",
+        "_dependencies": {
+          "esbuild": "^0.21.3",
+          "postcss": "^8.4.43",
+          "rollup": "^4.20.0",
+          "fsevents": "~2.3.3"
+        },
+        "devDependencies": {}
+      }
+    }
+  }
+}

--- a/scripts/audit.mjs
+++ b/scripts/audit.mjs
@@ -1,32 +1,115 @@
+import { execFile } from 'child_process';
 import fs from 'fs';
-import { execSync } from 'child_process';
 
-function runAudit() {
-  try {
-    const out = execSync('npm audit --json', { stdio: 'pipe' }).toString();
-    return JSON.parse(out);
-  } catch (e) {
-    console.error('npm audit failed, writing empty report');
-    if (e.stdout && e.stdout.length) {
-      try { return JSON.parse(e.stdout.toString()); } catch {}
+const REGISTRY = process.env.NPM_REGISTRY || 'https://registry.npmjs.org/';
+const TIMEOUT_MS = parseInt(process.env.AUDIT_TIMEOUT_MS || '30000', 10);
+const RETRIES = parseInt(process.env.AUDIT_RETRIES || '2', 10);
+const STRICT = process.env.AUDIT_STRICT === '1'; // if 1 -> exit 1 when unreachable
+
+function run(cmd, args, opts={}) {
+  return new Promise((resolve) => {
+    const child = execFile(cmd, args, { timeout: TIMEOUT_MS, ...opts }, (err, stdout, stderr) => {
+      resolve({ err, stdout: stdout?.toString() || '', stderr: stderr?.toString() || '' });
+    });
+  });
+}
+
+async function npmAuditJson() {
+  let lastErr;
+  for (let i = 0; i <= RETRIES; i++) {
+    const { err, stdout, stderr } = await run('npm', ['audit', '--json', `--registry=${REGISTRY}`]);
+    if (!err && stdout.trim()) {
+      try { return { ok: true, json: JSON.parse(stdout) }; }
+      catch (e) { lastErr = e; }
+    } else {
+      lastErr = err || new Error(stderr || 'audit error');
     }
-    return { metadata: { vulnerabilities: {} } };
   }
+  return { ok: false, error: lastErr };
 }
 
-function format(data) {
-  const levels = ['critical', 'high', 'moderate', 'low', 'info'];
-  const vuln = data.metadata?.vulnerabilities || {};
-  let md = '# npm audit report\n\n';
-  md += '## Summary\n';
-  for (const level of levels) {
-    const count = vuln[level] ?? 0;
-    md += `- ${level}: ${count}\n`;
-  }
-  md += `\nGenerated on ${new Date().toISOString()}\n`;
-  return md;
+async function npmLsDepth0() {
+  const { stdout } = await run('npm', ['ls', '--depth=0', '--json', '--long', '--silent']);
+  try { return JSON.parse(stdout || '{}'); } catch { return {}; }
 }
 
-const data = runAudit();
-fs.writeFileSync('AUDIT.md', format(data));
-console.log('Audit written to AUDIT.md');
+function summarizeAdvisories(auditJson) {
+  const out = { total: 0, critical: 0, high: 0, moderate: 0, low: 0, info: 0 };
+  if (!auditJson?.vulnerabilities) return out;
+  for (const v of Object.values(auditJson.vulnerabilities)) {
+    out.total += v?.via?.length ? 1 : 0;
+    const sev = (v.severity || '').toLowerCase();
+    if (out[sev] !== undefined) out[sev] += 1;
+  }
+  return out;
+}
+
+function writeFiles({ markdown, json }) {
+  fs.writeFileSync('AUDIT.md', markdown);
+  fs.writeFileSync('audit-report.json', JSON.stringify(json, null, 2));
+  console.log('Wrote AUDIT.md and audit-report.json');
+}
+
+function now() { return new Date().toISOString(); }
+
+(async () => {
+  console.log(`[audit] registry=${REGISTRY} timeout=${TIMEOUT_MS}ms retries=${RETRIES} strict=${STRICT}`);
+  const res = await npmAuditJson();
+
+  if (res.ok) {
+    const summary = summarizeAdvisories(res.json);
+    const md = [
+      '# Dependency Audit',
+      '',
+      `- Timestamp: ${now()}`,
+      `- Registry: ${REGISTRY}`,
+      '',
+      '## Summary',
+      `- total: ${summary.total}`,
+      `- critical: ${summary.critical}`,
+      `- high: ${summary.high}`,
+      `- moderate: ${summary.moderate}`,
+      `- low: ${summary.low}`,
+      `- info: ${summary.info}`,
+      '',
+      '## Notes',
+      '- This report was generated from `npm audit --json`.',
+      ''
+    ].join('\n');
+
+    writeFiles({ markdown: md, json: res.json });
+    process.exit(0);
+  }
+
+  // Fallback path (API unreachable or parse failure)
+  console.warn('[audit] audit API unreachable or parse failed. Writing fallback report…');
+  const ls = await npmLsDepth0();
+
+  const md = [
+    '# Dependency Audit',
+    '',
+    `- Timestamp: ${now()}`,
+    `- Registry: ${REGISTRY}`,
+    '',
+    '## Status',
+    '- ❗ Audit API unreachable – audit incomplete.',
+    '',
+    '## Installed top-level packages',
+    ...(Object.keys(ls.dependencies || {}).length
+      ? Object.entries(ls.dependencies).slice(0, 50).map(
+          ([name, info]) => `- ${name}@${info?.version || 'unknown'}`
+        )
+      : ['(none detected)']),
+    '',
+    '## Action',
+    '- Re-run with a working network or different registry.',
+    '- Example: `NPM_REGISTRY=https://registry.npmjs.org/ npm run audit`',
+    ''
+  ].join('\n');
+
+  writeFiles({ markdown: md, json: { error: String(res.error || 'unreachable'), ls } });
+  process.exit(STRICT ? 1 : 0);
+})().catch((e) => {
+  console.error('[audit] fatal error', e);
+  process.exit(STRICT ? 1 : 0);
+});


### PR DESCRIPTION
## Summary
- add audit script with retry, timeout, fallback to npm ls and strict mode option
- generate fallback audit report when audit API unreachable

## Testing
- `npm run build` *(fails: process hung, interrupted)*
- `npm run size` *(fails: manifest.json not found)*
- `npm run audit`


------
https://chatgpt.com/codex/tasks/task_e_68a063300560832f90c68ceecfa6c80d