### PR TITLE
fix(worker): guard canvas creation in workers using OffscreenCanvas

### DIFF
--- a/src/pdf/utils/detectWebP.ts
+++ b/src/pdf/utils/detectWebP.ts
@@ -1,7 +1,13 @@
+import { createSafeCanvas, canvasToBlob } from './safeCanvas';
+
 export async function supportsWebP(): Promise<boolean> {
   try {
-    const c = document.createElement('canvas');
-    return c.toDataURL('image/webp').startsWith('data:image/webp');
+    const c = createSafeCanvas(1, 1);
+    if ('toDataURL' in c) {
+      return (c as HTMLCanvasElement).toDataURL('image/webp').startsWith('data:image/webp');
+    }
+    const blob = await canvasToBlob(c, 'image/webp');
+    return blob.type === 'image/webp';
   } catch {
     return false;
   }

--- a/src/pdf/utils/pdfCanvas.ts
+++ b/src/pdf/utils/pdfCanvas.ts
@@ -1,5 +1,6 @@
 import { getPdfFromData } from './safePdf';
 import { ensurePdfWorker } from './ensurePdfWorker';
+import { createSafeCanvas, canvasToBlob } from './safeCanvas';
 
 export type RenderOpts = {
   data: ArrayBuffer; page: number; dpi: number; format: 'jpeg'|'webp'; quality: number;
@@ -11,28 +12,14 @@ export async function renderPageBlob(opts: RenderOpts): Promise<{blob:Blob; widt
   const page = await pdf.getPage(opts.page);
   const vp = page.getViewport({ scale: opts.dpi / 72 });
 
-  // OffscreenCanvas when available, fallback to HTMLCanvas
-  const anySelf: any = (typeof self !== 'undefined') ? self : globalThis;
-  let canvas: any;
-  if (typeof anySelf.OffscreenCanvas !== 'undefined') {
-    canvas = new anySelf.OffscreenCanvas(vp.width, vp.height);
-  } else {
-    // @ts-ignore
-    const c = (anySelf.document || {}).createElement ? anySelf.document.createElement('canvas') : null;
-    if (!c) throw new Error('Canvas not available');
-    c.width = vp.width; c.height = vp.height;
-    canvas = c;
-  }
+  // Safe canvas creation for both worker and main thread
+  const canvas: any = createSafeCanvas(vp.width, vp.height);
 
   const ctx = canvas.getContext('2d')!;
   await page.render({ canvasContext: ctx as any, viewport: vp }).promise;
 
   const type = opts.format === 'webp' ? 'image/webp' : 'image/jpeg';
-  const toBlob = (canvas as any).convertToBlob
-    ? (canvas as any).convertToBlob({ type, quality: opts.quality })
-    : new Promise<Blob>(res => (canvas as any).toBlob((b: Blob) => res(b!), type, opts.quality));
-
-  const blob: Blob = await toBlob;
+  const blob: Blob = await canvasToBlob(canvas, type, opts.quality);
   return { blob, width: vp.width, height: vp.height };
 }
 

--- a/src/pdf/utils/safeCanvas.ts
+++ b/src/pdf/utils/safeCanvas.ts
@@ -1,0 +1,42 @@
+/**
+ * Create a canvas safely in both environments:
+ * - In Web Workers: use OffscreenCanvas
+ * - In Window (main thread): fallback to document.createElement('canvas')
+ */
+export function createSafeCanvas(width: number, height: number) {
+  // OffscreenCanvas in worker (or supported window)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const OSC: any = (globalThis as unknown as { OffscreenCanvas?: unknown }).OffscreenCanvas;
+  if (typeof OSC !== 'undefined') {
+    const c = new (OSC as { new(w:number,h:number): OffscreenCanvas })(width, height);
+    // Provide a minimal 2D context API guard
+    return c;
+  }
+  // Main thread fallback
+  // @ts-ignore document may be undefined in some envs; guarded above
+  const doc = (globalThis as unknown as { document?: Document }).document;
+  if (!doc || !doc.createElement) {
+    throw new Error('No canvas available: OffscreenCanvas & document are unavailable');
+  }
+  const canvas = doc.createElement('canvas') as HTMLCanvasElement;
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+/** Convert either kind of canvas to Blob (PNG by default) */
+export async function canvasToBlob(
+  canvas: OffscreenCanvas | HTMLCanvasElement,
+  type = 'image/png',
+  quality?: number
+): Promise<Blob> {
+  if ('convertToBlob' in canvas) {
+    // OffscreenCanvas path
+    // @ts-ignore
+    return await canvas.convertToBlob({ type, quality });
+  }
+  // HTMLCanvasElement path
+  return await new Promise<Blob>((resolve) =>
+    (canvas as HTMLCanvasElement).toBlob((b) => resolve(b as Blob), type, quality)
+  );
+}


### PR DESCRIPTION
## Summary
- add `safeCanvas` utility to create canvases in both workers and main thread
- refactor PDF canvas and WebP detection to use the new helper

## Testing
- `npm run build`
- `npm run size`


------
https://chatgpt.com/codex/tasks/task_e_68a0839597ac832f882a57039827a446