### PR TITLE
Refine byte-size utility and fix lint warnings

### DIFF
--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -1,8 +1,8 @@
 export function bytesOf(v: any): number {
   if (!v) return 0;
-  if (typeof (v as any).size === 'number') return (v as any).size;
-  if (typeof (v as any).byteLength === 'number') return (v as any).byteLength;
-  if (typeof (v as any).length === 'number') return (v as any).length;
+  if (typeof v.size === 'number') return v.size;             // Blob/File
+  if (typeof v.byteLength === 'number') return v.byteLength; // ArrayBuffer/TypedArray
+  if (typeof v.length === 'number') return v.length;         // Uint8Array/Buffer
   if (typeof v === 'string') return new TextEncoder().encode(v).length;
   return 0;
 }

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -3,9 +3,9 @@ export const storage = {
     try { return window.localStorage.getItem(k); } catch { return null; }
   },
   set(k: string, v: string) {
-    try { window.localStorage.setItem(k, v); } catch {}
+    try { window.localStorage.setItem(k, v); } catch { /* empty */ }
   },
   remove(k: string) {
-    try { window.localStorage.removeItem(k); } catch {}
+    try { window.localStorage.removeItem(k); } catch { /* empty */ }
   }
 };


### PR DESCRIPTION
## Summary
- rewrite `bytesOf` helper to detect byte size via native properties
- clarify localStorage error suppression to satisfy eslint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a1703ce834832f92ef3c4d22449f19