### PR TITLE
fix: safe canvas creation for workers/SSR, remove direct document usage

### DIFF
--- a/src/AppErrorBoundary.tsx
+++ b/src/AppErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { isBrowser } from "@/utils/env";
 
 interface Props {
   children: React.ReactNode;
@@ -17,7 +18,7 @@ export default class AppErrorBoundary extends React.Component<Props, State> {
   }
 
   override componentDidCatch(error: unknown, errorInfo: unknown) {
-    if (import.meta.env.VITE_DEBUG)
+    if (import.meta.env.VITE_DEBUG && isBrowser)
       console.error("error", window.location.pathname, error, errorInfo);
   }
 

--- a/src/app/components/ResultDownloadCard.tsx
+++ b/src/app/components/ResultDownloadCard.tsx
@@ -1,31 +1,41 @@
 import { formatBytes } from "@/pdf/utils";
+import { isBrowser } from "@/utils/env";
 
 type Props = {
   srcName: string;
-  srcSize?: number;          // in bytes
+  srcSize?: number; // in bytes
   outName: string;
-  outBlob: Blob;             // Blob to download
+  outBlob: Blob; // Blob to download
   meta?: any;
   onReset?: () => void;
 };
 
-export default function ResultDownloadCard({ srcName, srcSize, outName, outBlob, meta, onReset }: Props) {
+export default function ResultDownloadCard({
+  srcName,
+  srcSize,
+  outName,
+  outBlob,
+  meta,
+  onReset,
+}: Props) {
   const outSize = outBlob.size;
   const deltaPct = srcSize != null ? ((outSize - srcSize) / srcSize) * 100 : null;
   const badges: string[] = [];
-  if (meta?.pipeline !== 'rasterAll') {
-    badges.push('ATS-safe', 'Searchable');
+  if (meta?.pipeline !== "rasterAll") {
+    badges.push("ATS-safe", "Searchable");
   }
-  if (meta?.pipeline !== 'losslessClean') {
-    badges.push('Lossy');
+  if (meta?.pipeline !== "losslessClean") {
+    badges.push("Lossy");
   }
-  if (meta?.ocr === 'tesseract.js') badges.push('OCR: tesseract.js');
-  if (meta?.ocr === 'stub') badges.push('OCR offline (stub)');
-  const hint = srcSize != null && outSize > srcSize
-    ? 'This preset kept vector text or metadata; try Smart or lower DPI/quality.'
-    : null;
+  if (meta?.ocr === "tesseract.js") badges.push("OCR: tesseract.js");
+  if (meta?.ocr === "stub") badges.push("OCR offline (stub)");
+  const hint =
+    srcSize != null && outSize > srcSize
+      ? "This preset kept vector text or metadata; try Smart or lower DPI/quality."
+      : null;
 
   const handleDownload = () => {
+    if (!isBrowser) return;
     const url = URL.createObjectURL(outBlob);
     const a = document.createElement("a");
     a.href = url;
@@ -38,23 +48,46 @@ export default function ResultDownloadCard({ srcName, srcSize, outName, outBlob,
     <div className="card" style={{ marginTop: 12 }}>
       <h3 style={{ marginTop: 0 }}>Result</h3>
       <div className="mono" style={{ display: "grid", gap: 4 }}>
-        <div>Source file: <strong>{srcName}</strong>{srcSize!=null ? ` - ${formatBytes(srcSize)}` : ""}</div>
-        <div>Output file: <strong>{outName}</strong> - {formatBytes(outSize)}</div>
-        {deltaPct!=null && (
-          <div>Δ {deltaPct>0?'+':''}{deltaPct.toFixed(1)}%</div>
+        <div>
+          Source file: <strong>{srcName}</strong>
+          {srcSize != null ? ` - ${formatBytes(srcSize)}` : ""}
+        </div>
+        <div>
+          Output file: <strong>{outName}</strong> - {formatBytes(outSize)}
+        </div>
+        {deltaPct != null && (
+          <div>
+            Δ {deltaPct > 0 ? "+" : ""}
+            {deltaPct.toFixed(1)}%
+          </div>
         )}
       </div>
       {badges.length > 0 && (
-        <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' }}>
+        <div style={{ display: "flex", gap: 6, marginTop: 8, flexWrap: "wrap" }}>
           {badges.map((b) => (
-            <span key={b} style={{ padding: '2px 6px', background: '#eee', borderRadius: 4, fontSize: 12 }}>{b}</span>
+            <span
+              key={b}
+              style={{ padding: "2px 6px", background: "#eee", borderRadius: 4, fontSize: 12 }}
+            >
+              {b}
+            </span>
           ))}
         </div>
       )}
-      {hint && <p className="mono" style={{ color: 'orange', marginTop: 8 }}>{hint}</p>}
+      {hint && (
+        <p className="mono" style={{ color: "orange", marginTop: 8 }}>
+          {hint}
+        </p>
+      )}
       <div style={{ display: "flex", gap: 10, marginTop: 12, flexWrap: "wrap" }}>
-        <button className="btn" onClick={handleDownload} aria-label="Download processed file">Download</button>
-        {onReset && <button className="btn ghost" onClick={onReset}>Process another</button>}
+        <button className="btn" onClick={handleDownload} aria-label="Download processed file">
+          Download
+        </button>
+        {onReset && (
+          <button className="btn ghost" onClick={onReset}>
+            Process another
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/app/hooks/useMeta.ts
+++ b/src/app/hooks/useMeta.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { isBrowser } from "@/utils/env";
 
 interface MetaOptions {
   title: string;
@@ -7,12 +8,13 @@ interface MetaOptions {
 
 export function useMeta({ title, description }: MetaOptions) {
   useEffect(() => {
+    if (!isBrowser) return;
     if (title) document.title = title;
     if (description) {
       let tag = document.querySelector<HTMLMetaElement>('meta[name="description"]');
       if (!tag) {
-        tag = document.createElement('meta');
-        tag.name = 'description';
+        tag = document.createElement("meta");
+        tag.name = "description";
         document.head.appendChild(tag);
       }
       tag.content = description;

--- a/src/app/routes/cv/Samples.tsx
+++ b/src/app/routes/cv/Samples.tsx
@@ -1,29 +1,57 @@
-import { jsPDF } from 'jspdf';
-import React from 'react';
+import { jsPDF } from "jspdf";
+import React from "react";
+import { isBrowser } from "@/utils/env";
 
-export default function Samples(){
-  async function makeTextOnly(){
-    const doc = new jsPDF(); doc.setFontSize(12);
-    for(let p=0;p<3;p++){ if(p) doc.addPage(); for(let i=0;i<40;i++) doc.text(`Line ${i+1} — Lorem ipsum dolor sit amet.`, 20, 20 + i*12); }
-    return new Blob([doc.output('arraybuffer')], { type:'application/pdf' });
+export default function Samples() {
+  async function makeTextOnly() {
+    const doc = new jsPDF();
+    doc.setFontSize(12);
+    for (let p = 0; p < 3; p++) {
+      if (p) doc.addPage();
+      for (let i = 0; i < 40; i++)
+        doc.text(`Line ${i + 1} — Lorem ipsum dolor sit amet.`, 20, 20 + i * 12);
+    }
+    return new Blob([doc.output("arraybuffer")], { type: "application/pdf" });
   }
-  async function makeImageHeavy(){
-    const doc = new jsPDF(); const img = await fetch('https://picsum.photos/1200/1600').then(r=>r.blob());
-    const dataUrl = await new Promise<string>(res => { const fr = new FileReader(); fr.onload=()=>res(fr.result as string); fr.readAsDataURL(img); });
-    for(let p=0;p<3;p++){ if(p) doc.addPage(); doc.addImage(dataUrl, 'JPEG', 0, 0, 595, 842); }
-    return new Blob([doc.output('arraybuffer')], { type:'application/pdf' });
+  async function makeImageHeavy() {
+    const doc = new jsPDF();
+    const img = await fetch("https://picsum.photos/1200/1600").then((r) => r.blob());
+    const dataUrl = await new Promise<string>((res) => {
+      const fr = new FileReader();
+      fr.onload = () => res(fr.result as string);
+      fr.readAsDataURL(img);
+    });
+    for (let p = 0; p < 3; p++) {
+      if (p) doc.addPage();
+      doc.addImage(dataUrl, "JPEG", 0, 0, 595, 842);
+    }
+    return new Blob([doc.output("arraybuffer")], { type: "application/pdf" });
   }
 
-  async function download(name: string, blob: Blob){
-    const a = document.createElement('a'); a.href = URL.createObjectURL(blob); a.download = name; a.click(); setTimeout(()=>URL.revokeObjectURL(a.href), 1000);
+  async function download(name: string, blob: Blob) {
+    if (!isBrowser) return;
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = name;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(a.href), 1000);
   }
 
   return (
     <div className="p-6 space-y-4">
       <h1 className="text-2xl font-bold">Sample PDFs</h1>
-      <button onClick={async()=>download('text-only.pdf', await makeTextOnly())} className="btn">Generate text-only</button>
-      <button onClick={async()=>download('image-heavy.pdf', await makeImageHeavy())} className="btn">Generate image-heavy</button>
-      <p className="text-sm opacity-70">Use these to measure Compress presets (Smart, ATS-safe, Email&lt;2MB, Smallest).</p>
+      <button onClick={async () => download("text-only.pdf", await makeTextOnly())} className="btn">
+        Generate text-only
+      </button>
+      <button
+        onClick={async () => download("image-heavy.pdf", await makeImageHeavy())}
+        className="btn"
+      >
+        Generate image-heavy
+      </button>
+      <p className="text-sm opacity-70">
+        Use these to measure Compress presets (Smart, ATS-safe, Email&lt;2MB, Smallest).
+      </p>
     </div>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import AppErrorBoundary from "./AppErrorBoundary";
 import "./ui/theme.css";
 import "./ui/ui.css";
+import { isBrowser } from "@/utils/env";
 
 const routes: Record<string, () => Promise<{ default: React.ComponentType<any> }>> = {
   "/": () => import("@/app/routes/Home"),
@@ -22,17 +23,19 @@ const routes: Record<string, () => Promise<{ default: React.ComponentType<any> }
   "/contact": () => import("@/app/routes/Contact"),
 };
 
-const loadRoute = (routes[window.location.pathname] || routes["/"]) as () => Promise<{
-  default: React.ComponentType<any>;
-}>;
-const LazyComp = lazy(loadRoute);
+if (isBrowser) {
+  const loadRoute = (routes[window.location.pathname] || routes["/"]) as () => Promise<{
+    default: React.ComponentType<any>;
+  }>;
+  const LazyComp = lazy(loadRoute);
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <AppErrorBoundary>
-      <Suspense fallback={<div />}> 
-        <LazyComp />
-      </Suspense>
-    </AppErrorBoundary>
-  </React.StrictMode>
-);
+  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <React.StrictMode>
+      <AppErrorBoundary>
+        <Suspense fallback={<div />}>
+          <LazyComp />
+        </Suspense>
+      </AppErrorBoundary>
+    </React.StrictMode>,
+  );
+}

--- a/src/pdf/pipelines/searchableImage.ts
+++ b/src/pdf/pipelines/searchableImage.ts
@@ -1,95 +1,122 @@
-import { getPdfFromData } from '../utils/safePdf';
-import { jsPDF } from 'jspdf';
-import { renderPageBlob } from '../utils/pdfCanvas';
-import { ensurePdfWorker } from '../utils/ensurePdfWorker';
+import { getPdfFromData } from "../utils/safePdf";
+import { jsPDF } from "jspdf";
+import { renderPageBlob } from "../utils/pdfCanvas";
+import { ensurePdfWorker } from "../utils/ensurePdfWorker";
+import { createSafeCanvas, get2d } from "../utils/safeCanvas";
 
-type Cfg = { dpi:number; quality:number; format:'jpeg'|'webp'; lang?:string; onProgress?:(p:any)=>void };
+type Cfg = {
+  dpi: number;
+  quality: number;
+  format: "jpeg" | "webp";
+  lang?: string;
+  onProgress?: (p: any) => void;
+};
 
 let tesseractWorker: any | null = null;
-let ocrEngine: 'tesseract.js'|'stub'|null = null;
-async function getOcrWorker(lang='eng'){
+let ocrEngine: "tesseract.js" | "stub" | null = null;
+async function getOcrWorker(lang = "eng") {
   if (tesseractWorker) return tesseractWorker;
   try {
-    const { createWorker } = await import('tesseract.js');
-    const worker = await createWorker({ langPath: 'https://tessdata.projectnaptha.com/4.0.0' });
+    const { createWorker } = await import("tesseract.js");
+    const worker = await createWorker({ langPath: "https://tessdata.projectnaptha.com/4.0.0" });
     await worker.loadLanguage(lang);
     await worker.initialize(lang);
-    ocrEngine = 'tesseract.js';
+    ocrEngine = "tesseract.js";
     tesseractWorker = worker;
     return worker;
   } catch (e) {
-    const { createWorker } = await import('../../stubs/tesseract');
-    ocrEngine = 'stub';
+    const { createWorker } = await import("../../stubs/tesseract");
+    ocrEngine = "stub";
     tesseractWorker = await createWorker(lang);
     return tesseractWorker;
   }
 }
-export function getOcrEngine(){ return ocrEngine; }
+export function getOcrEngine() {
+  return ocrEngine;
+}
 
-export async function searchableImage(data:ArrayBuffer, cfg:Cfg): Promise<Blob> {
+export async function searchableImage(data: ArrayBuffer, cfg: Cfg): Promise<Blob> {
   ocrEngine = null;
   await ensurePdfWorker();
   const pdf = await getPdfFromData(data);
-  const doc = new jsPDF({ unit:'pt', compress:true });
+  const doc = new jsPDF({ unit: "pt", compress: true });
 
-  for (let p=1;p<=pdf.numPages;p++){
-    cfg.onProgress?.({stage:'render', page:p, total:pdf.numPages});
+  for (let p = 1; p <= pdf.numPages; p++) {
+    cfg.onProgress?.({ stage: "render", page: p, total: pdf.numPages });
     const page = await pdf.getPage(p);
     const vp = page.getViewport({ scale: cfg.dpi / 72 });
-    const { blob } = await renderPageBlob({ data, page: p, dpi: cfg.dpi, format: cfg.format, quality: cfg.quality });
+    const { blob } = await renderPageBlob({
+      data,
+      page: p,
+      dpi: cfg.dpi,
+      format: cfg.format,
+      quality: cfg.quality,
+    });
     const dataUrl = await blobToDataURL(blob);
 
-    if (p>1) doc.addPage([vp.width, vp.height]); else (doc as any).setPage(1);
-    doc.addImage(dataUrl, cfg.format==='webp'?'WEBP':'JPEG', 0, 0, vp.width, vp.height);
+    if (p > 1) doc.addPage([vp.width, vp.height]);
+    else (doc as any).setPage(1);
+    doc.addImage(dataUrl, cfg.format === "webp" ? "WEBP" : "JPEG", 0, 0, vp.width, vp.height);
 
     // Try native text first
     let items;
-    try { items = await page.getTextContent(); } catch { items = { items: [] }; }
-    if ((items.items?.length ?? 0) < 5){
+    try {
+      items = await page.getTextContent();
+    } catch {
+      items = { items: [] };
+    }
+    if ((items.items?.length ?? 0) < 5) {
       // OCR fallback
-      cfg.onProgress?.({stage:'ocr', page:p, total:pdf.numPages});
-      const worker = await getOcrWorker(cfg.lang || 'eng');
-      const canvas = new OffscreenCanvas(vp.width, vp.height);
-      const ctx = canvas.getContext('2d')!;
+      cfg.onProgress?.({ stage: "ocr", page: p, total: pdf.numPages });
+      const worker = await getOcrWorker(cfg.lang || "eng");
+      const canvas = createSafeCanvas(vp.width, vp.height);
+      const ctx = get2d(canvas);
       await page.render({ canvasContext: ctx as any, viewport: vp }).promise;
       const { data: ocr } = await worker.recognize(canvas);
       overlayOcr(doc, vp.height, ocr);
     } else {
       overlayPdfjsItems(doc, vp.height, items);
     }
-    cfg.onProgress?.({stage:'compose', page:p, total:pdf.numPages});
+    cfg.onProgress?.({ stage: "compose", page: p, total: pdf.numPages });
   }
-  return doc.output('blob');
+  return doc.output("blob");
 }
 
-function overlayPdfjsItems(doc: jsPDF, pageHeight: number, textContent: any){
+function overlayPdfjsItems(doc: jsPDF, pageHeight: number, textContent: any) {
   (doc as any).setGState(new (doc as any).GState({ opacity: 0 }));
-  doc.setTextColor(0,0,0);
-  for (const it of textContent.items){
+  doc.setTextColor(0, 0, 0);
+  for (const it of textContent.items) {
     const [a, b, , , e, f] = it.transform; // pdfjs transform
-    const x = e; const yTop = f;
+    const x = e;
+    const yTop = f;
     const fontSize = Math.hypot(a, b); // approx
     const yPdf = pageHeight - yTop;
     doc.setFontSize(fontSize || 10);
-    doc.text(String(it.str || ''), x, yPdf, { baseline: 'top' });
+    doc.text(String(it.str || ""), x, yPdf, { baseline: "top" });
   }
 }
 
-function overlayOcr(doc: jsPDF, pageHeight: number, ocr: any){
+function overlayOcr(doc: jsPDF, pageHeight: number, ocr: any) {
   (doc as any).setGState(new (doc as any).GState({ opacity: 0 }));
-  doc.setTextColor(0,0,0);
-  for (const block of ocr.blocks || []){
-    for (const para of block.paragraphs || []){
-      for (const line of para.lines || []){
-        const t = line.text || '';
-        const { x0,y0,y1 } = line.bbox;
+  doc.setTextColor(0, 0, 0);
+  for (const block of ocr.blocks || []) {
+    for (const para of block.paragraphs || []) {
+      for (const line of para.lines || []) {
+        const t = line.text || "";
+        const { x0, y0, y1 } = line.bbox;
         const fs = Math.max(8, y1 - y0);
         doc.setFontSize(fs);
         const yPdf = pageHeight - y0;
-        doc.text(t, x0, yPdf, { baseline: 'bottom' });
+        doc.text(t, x0, yPdf, { baseline: "bottom" });
       }
     }
   }
 }
 
-function blobToDataURL(b:Blob){ return new Promise<string>(res=>{ const r=new FileReader(); r.onload=()=>res(r.result as string); r.readAsDataURL(b); }); }
+function blobToDataURL(b: Blob) {
+  return new Promise<string>((res) => {
+    const r = new FileReader();
+    r.onload = () => res(r.result as string);
+    r.readAsDataURL(b);
+  });
+}

--- a/src/pdf/utils/pdfCanvas.ts
+++ b/src/pdf/utils/pdfCanvas.ts
@@ -1,29 +1,34 @@
-import { getPdfFromData } from './safePdf';
-import { ensurePdfWorker } from './ensurePdfWorker';
-import { createSafeCanvas, canvasToBlob } from './safeCanvas';
+import { getPdfFromData } from "./safePdf";
+import { ensurePdfWorker } from "./ensurePdfWorker";
+import { createSafeCanvas, canvasToBlob, get2d } from "./safeCanvas";
 
 export type RenderOpts = {
-  data: ArrayBuffer; page: number; dpi: number; format: 'jpeg'|'webp'; quality: number;
+  data: ArrayBuffer;
+  page: number;
+  dpi: number;
+  format: "jpeg" | "webp";
+  quality: number;
 };
 
-export async function renderPageBlob(opts: RenderOpts): Promise<{blob:Blob; width:number; height:number}> {
+export async function renderPageBlob(
+  opts: RenderOpts,
+): Promise<{ blob: Blob; width: number; height: number }> {
   await ensurePdfWorker();
   const pdf = await getPdfFromData(opts.data);
   const page = await pdf.getPage(opts.page);
   const vp = page.getViewport({ scale: opts.dpi / 72 });
 
   // Safe canvas creation for both worker and main thread
-  const canvas: any = createSafeCanvas(vp.width, vp.height);
-
-  const ctx = canvas.getContext('2d')!;
+  const canvas = createSafeCanvas(vp.width, vp.height);
+  const ctx = get2d(canvas);
   await page.render({ canvasContext: ctx as any, viewport: vp }).promise;
 
-  const type = opts.format === 'webp' ? 'image/webp' : 'image/jpeg';
+  const type = opts.format === "webp" ? "image/webp" : "image/jpeg";
   const blob: Blob = await canvasToBlob(canvas, type, opts.quality);
   return { blob, width: vp.width, height: vp.height };
 }
 
-export async function textItemsForPage(data: ArrayBuffer, pageNo: number){
+export async function textItemsForPage(data: ArrayBuffer, pageNo: number) {
   await ensurePdfWorker();
   const pdf = await getPdfFromData(data);
   const page = await pdf.getPage(pageNo);

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,3 @@
+export const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
+
+export const isWorker = typeof self !== "undefined" && typeof Window === "undefined";

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -1,11 +1,28 @@
+import { isBrowser } from "@/utils/env";
+
 export const storage = {
   get(k: string) {
-    try { return window.localStorage.getItem(k); } catch { return null; }
+    if (!isBrowser) return null;
+    try {
+      return window.localStorage.getItem(k);
+    } catch {
+      return null;
+    }
   },
   set(k: string, v: string) {
-    try { window.localStorage.setItem(k, v); } catch { /* empty */ }
+    if (!isBrowser) return;
+    try {
+      window.localStorage.setItem(k, v);
+    } catch {
+      /* empty */
+    }
   },
   remove(k: string) {
-    try { window.localStorage.removeItem(k); } catch { /* empty */ }
-  }
+    if (!isBrowser) return;
+    try {
+      window.localStorage.removeItem(k);
+    } catch {
+      /* empty */
+    }
+  },
 };


### PR DESCRIPTION
## Summary
- add environment helpers and safe canvas utilities
- guard DOM access for SSR/worker safety

## Testing
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68a179e3ac54832f8ea1059048a633f2