### PR TITLE
fix: canvas in worker (no DOM) – image-only stable, API unchanged

### DIFF
--- a/src/pdf/pipelines/rasterAll.ts
+++ b/src/pdf/pipelines/rasterAll.ts
@@ -23,6 +23,10 @@ export async function rasterAll(data:ArrayBuffer, cfg:RasterCfg): Promise<Blob> 
   return out!.output('blob');
 }
 
-function blobToDataURL(b:Blob){
-  return new Promise<string>(res => { const r=new FileReader(); r.onload=()=>res(r.result as string); r.readAsDataURL(b); });
+async function blobToDataURL(b: Blob){
+  const buf = await b.arrayBuffer();
+  const base64 = typeof btoa === 'function'
+    ? btoa(String.fromCharCode(...new Uint8Array(buf)))
+    : Buffer.from(buf).toString('base64');
+  return `data:${b.type};base64,${base64}`;
 }

--- a/src/pdf/utils/detectWebP.ts
+++ b/src/pdf/utils/detectWebP.ts
@@ -1,12 +1,12 @@
-import { createSafeCanvas, canvasToBlob } from './safeCanvas';
+import { createCanvas, canvasToBlob } from './safeCanvas';
 
 export async function supportsWebP(): Promise<boolean> {
   try {
-    const c = createSafeCanvas(1, 1);
-    if ('toDataURL' in c) {
-      return (c as HTMLCanvasElement).toDataURL('image/webp').startsWith('data:image/webp');
+    const { canvas } = createCanvas(1, 1);
+    if ('toDataURL' in canvas) {
+      return (canvas as HTMLCanvasElement).toDataURL('image/webp').startsWith('data:image/webp');
     }
-    const blob = await canvasToBlob(c, 'image/webp');
+    const blob = await canvasToBlob(canvas, 'image/webp');
     return blob.type === 'image/webp';
   } catch {
     return false;

--- a/src/pdf/utils/pdfCanvas.ts
+++ b/src/pdf/utils/pdfCanvas.ts
@@ -1,6 +1,6 @@
 import { getPdfFromData } from "./safePdf";
 import { ensurePdfWorker } from "./ensurePdfWorker";
-import { createSafeCanvas, canvasToBlob, get2d } from "./safeCanvas";
+import { createCanvas, canvasToBlob } from "./safeCanvas";
 
 export type RenderOpts = {
   data: ArrayBuffer;
@@ -19,8 +19,7 @@ export async function renderPageBlob(
   const vp = page.getViewport({ scale: opts.dpi / 72 });
 
   // Safe canvas creation for both worker and main thread
-  const canvas = createSafeCanvas(vp.width, vp.height);
-  const ctx = get2d(canvas);
+  const { canvas, ctx } = createCanvas(vp.width, vp.height);
   await page.render({ canvasContext: ctx as any, viewport: vp }).promise;
 
   const type = opts.format === "webp" ? "image/webp" : "image/jpeg";


### PR DESCRIPTION
## Summary
- add `createCanvas` helper with OffscreenCanvas support
- use helper across raster pipelines to avoid `document.createElement`
- convert image blobs to base64 without DOM APIs in workers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68a285c498ec832f93f66cb186283392