### PR TITLE
fix: resolve stack overflow in rasterization – API unchanged

### DIFF
--- a/src/pdf/pipelines/rasterAll.ts
+++ b/src/pdf/pipelines/rasterAll.ts
@@ -25,8 +25,14 @@ export async function rasterAll(data:ArrayBuffer, cfg:RasterCfg): Promise<Blob> 
 
 async function blobToDataURL(b: Blob){
   const buf = await b.arrayBuffer();
+  const bytes = new Uint8Array(buf);
+  let binary = '';
+  const chunk = 0x8000; // avoid stack overflow for large pages
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
   const base64 = typeof btoa === 'function'
-    ? btoa(String.fromCharCode(...new Uint8Array(buf)))
+    ? btoa(binary)
     : Buffer.from(buf).toString('base64');
   return `data:${b.type};base64,${base64}`;
 }


### PR DESCRIPTION
## Summary
- avoid large `String.fromCharCode` spreads when converting rasterized pages to base64
- keep compress API and structure intact

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a28997d96c832fa5066a4cd2888081