### PR TITLE
QA: Automated checks for PDF tools (Compress/Merge/OCR/ATS/Split)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,32 @@
+name: e2e
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  qa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run gen:fixtures
+      - run: npm run qa:local
+      - name: Run prod suite
+        if: env.E2E_PROD_BASE
+        env:
+          E2E_BASE: ${{ env.E2E_PROD_BASE }}
+          E2E_REPORT_DIR: e2e/.reports/prod
+        run: npm run e2e
+      - uses: actions/upload-artifact@v3
+        with:
+          name: e2e-artifacts
+          path: |
+            TOOL_STATUS.md
+            e2e/.reports
+            e2e/.artifacts
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ dist/
 *.gif
 *.mp4
 *.png
+e2e/fixtures/out/
+e2e/.artifacts/
+e2e/.reports/
+.env.e2e.local
+e2e/.preview.pid

--- a/TOOL_STATUS.md
+++ b/TOOL_STATUS.md
@@ -1,0 +1,4 @@
+# TOOL STATUS
+
+| Feature | Checks | Result | Notes | Local Report Path | Prod Report Path |
+| --- | --- | --- | --- | --- | --- |

--- a/e2e/fixtures/generate-fixtures.ts
+++ b/e2e/fixtures/generate-fixtures.ts
@@ -1,0 +1,100 @@
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+import fs from 'fs';
+import path from 'path';
+import Jimp from 'jimp';
+
+const outDir = path.join(__dirname, 'out');
+fs.mkdirSync(outDir, { recursive: true });
+
+async function createImgHeavy() {
+  const pdf = await PDFDocument.create();
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+
+  for (let i = 1; i <= 4; i++) {
+    const page = pdf.addPage([600, 800]);
+    const img = await Jimp.create(2000, 2000, i % 2 === 0 ? 0xff0000ff : 0x00ff00ff);
+    const buf = await img.getBufferAsync(Jimp.MIME_PNG);
+    const embedded = await pdf.embedPng(buf);
+    const { width, height } = embedded.scale(0.5);
+    page.drawImage(embedded, { x: 0, y: 0, width, height });
+    page.drawText(`IMG_HEAVY_PAGE_${i}`, { x: 50, y: 760, size: 24, font, color: rgb(0, 0, 0) });
+  }
+
+  const bytes = await pdf.save();
+  fs.writeFileSync(path.join(outDir, 'img-heavy.pdf'), bytes);
+}
+
+async function createVectorOnly() {
+  const pdf = await PDFDocument.create();
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  for (let i = 1; i <= 3; i++) {
+    const page = pdf.addPage([600, 800]);
+    page.drawRectangle({ x: 50, y: 650, width: 500, height: 100, color: rgb(0.2, 0.2, 0.7) });
+    page.drawText(`VECTOR_ONLY_PAGE_${i}`, { x: 60, y: 700, size: 24, font, color: rgb(1, 1, 1) });
+  }
+  const bytes = await pdf.save();
+  fs.writeFileSync(path.join(outDir, 'vector-only.pdf'), bytes);
+}
+
+async function createScannedLike() {
+  const pdf = await PDFDocument.create();
+  for (let i = 1; i <= 2; i++) {
+    const img = await Jimp.create(1000, 1000, 0xffffffff);
+    const fontJ = await Jimp.loadFont(Jimp.FONT_SANS_64_BLACK);
+    img.print(fontJ, 50, 450, 'THE QUICK BROWN FOX 12345');
+    const buf = await img.getBufferAsync(Jimp.MIME_PNG);
+    const page = pdf.addPage([600, 800]);
+    const embedded = await pdf.embedPng(buf);
+    const { width, height } = embedded.scale(0.5);
+    page.drawImage(embedded, { x: 0, y: 0, width, height });
+  }
+  const bytes = await pdf.save();
+  fs.writeFileSync(path.join(outDir, 'scanned-like.pdf'), bytes);
+}
+
+async function createPortfolio(name: 'A' | 'B') {
+  const pdf = await PDFDocument.create();
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  for (let i = 1; i <= 2; i++) {
+    const page = pdf.addPage([600, 800]);
+    page.drawText(`FILE_${name}_P${i}`, { x: 100, y: 700, size: 48, font, color: rgb(0, 0, 0) });
+  }
+  const bytes = await pdf.save();
+  fs.writeFileSync(path.join(outDir, `portfolio-${name}.pdf`), bytes);
+}
+
+async function createAtsTest() {
+  const pdf = await PDFDocument.create();
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  for (let i = 1; i <= 3; i++) {
+    const page = pdf.addPage([600, 800]);
+    page.drawText(`SeniorFitGuide — Page ${i}`, { x: 50, y: 760, size: 18, font });
+    page.drawText('© 2025', { x: 50, y: 40, size: 14, font });
+    const body = 'This guide covers marketing, analytics, Google Ads, CRM.';
+    page.drawText(body, { x: 50, y: 600, size: 16, font, maxWidth: 500, lineHeight: 20 });
+  }
+  const bytes = await pdf.save();
+  fs.writeFileSync(path.join(outDir, 'ats-test.pdf'), bytes);
+}
+
+function createNotPdf() {
+  fs.writeFileSync(path.join(outDir, 'not-a-pdf.txt'), 'This is not a PDF');
+}
+
+async function main() {
+  await Promise.all([
+    createImgHeavy(),
+    createVectorOnly(),
+    createScannedLike(),
+    createPortfolio('A'),
+    createPortfolio('B'),
+    createAtsTest()
+  ]);
+  createNotPdf();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+

--- a/e2e/scripts/preview-start.ts
+++ b/e2e/scripts/preview-start.ts
@@ -1,0 +1,28 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const pidFile = path.join(__dirname, '../.preview.pid');
+const envFile = path.join(__dirname, '../../.env.e2e.local');
+
+const proc = spawn('npx', ['vite', 'preview'], {
+  env: process.env,
+  stdio: ['ignore', 'pipe', 'pipe'],
+  detached: true
+});
+
+proc.stdout.on('data', (chunk) => {
+  const text = chunk.toString();
+  process.stdout.write(text);
+  const match = text.match(/http:\/\/localhost:(\d+)/);
+  if (match) {
+    const base = `http://localhost:${match[1]}`;
+    fs.writeFileSync(envFile, `E2E_BASE=${base}\n`);
+    fs.writeFileSync(pidFile, String(proc.pid));
+  }
+});
+
+proc.stderr.on('data', (d) => process.stderr.write(d.toString()));
+
+proc.unref();
+

--- a/e2e/scripts/preview-stop.ts
+++ b/e2e/scripts/preview-stop.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+import path from 'path';
+
+const pidFile = path.join(__dirname, '../.preview.pid');
+
+if (fs.existsSync(pidFile)) {
+  const pid = Number(fs.readFileSync(pidFile, 'utf8'));
+  try {
+    process.kill(pid);
+  } catch (err) {
+    // ignore
+  }
+  fs.unlinkSync(pidFile);
+}
+

--- a/e2e/scripts/tool-status.ts
+++ b/e2e/scripts/tool-status.ts
@@ -1,0 +1,6 @@
+import fs from 'fs';
+
+const content = `# TOOL STATUS\n\n| Feature | Checks | Result | Notes | Local Report Path | Prod Report Path |\n| --- | --- | --- | --- | --- | --- |\n`;
+
+fs.writeFileSync('TOOL_STATUS.md', content);
+

--- a/e2e/tests/app.smoke.spec.ts
+++ b/e2e/tests/app.smoke.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+const TOOL_PATHS = ['compress', 'merge', 'ocr', 'ats', 'split'];
+
+test('app renders without console errors and tools mount', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+
+  await page.goto('/');
+  await expect(page.locator('header')).toBeVisible();
+  await expect(page.locator('footer')).toBeVisible();
+
+  for (const tool of TOOL_PATHS) {
+    const link = page.locator(`a[href*="${tool}"]`).first();
+    if (await link.count()) {
+      await link.click();
+      const dz = page.locator('[data-testid="dropzone"], [data-testid="main-cta"], input[type=file]');
+      await expect(dz.first()).toBeVisible();
+      await page.goBack();
+    }
+  }
+
+  expect(errors).toEqual([]);
+});
+

--- a/e2e/tests/ats-export.spec.ts
+++ b/e2e/tests/ats-export.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+import { getPdfText } from '../utils/pdf';
+
+const fixtures = path.join('e2e', 'fixtures', 'out');
+const outDir = path.join('e2e', '.artifacts', 'ats');
+fs.mkdirSync(outDir, { recursive: true });
+
+test('ATS export cleans text', async ({ page }) => {
+  await page.goto('/ats');
+  const input = page.locator('input[type=file]').first();
+  await input.setInputFiles(path.join(fixtures, 'ats-test.pdf'));
+  const btn = page.locator('button:has-text("Export")').first();
+  await btn.click();
+  const download = await page.waitForEvent('download');
+  const dest = path.join(outDir, download.suggestedFilename());
+  await download.saveAs(dest);
+  let text: string;
+  if (dest.endsWith('.txt')) {
+    text = fs.readFileSync(dest, 'utf8');
+  } else {
+    text = await getPdfText(fs.readFileSync(dest));
+  }
+  expect(text).not.toContain('© 2025');
+  const headerCount = (text.match(/SeniorFitGuide — Page/g) || []).length;
+  expect(headerCount).toBeLessThanOrEqual(1);
+  expect(text).toMatch(/marketing/);
+  expect(text).toMatch(/CRM/);
+  expect(text).toMatch(/Google Ads/);
+  expect(text).not.toMatch(/\s{3,}/);
+});
+

--- a/e2e/tests/compress.spec.ts
+++ b/e2e/tests/compress.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+import { getFileSize, percentDelta } from '../utils/pdf';
+
+const fixtures = path.join('e2e', 'fixtures', 'out');
+const outDir = path.join('e2e', '.artifacts', 'compress');
+fs.mkdirSync(outDir, { recursive: true });
+
+const profiles = ['max', 'balanced', 'lossless'];
+
+for (const profile of profiles) {
+  test(`compress img-heavy with profile ${profile}`, async ({ page }) => {
+    await page.goto('/compress');
+    const input = page.locator('input[type=file]').first();
+    const src = path.join(fixtures, 'img-heavy.pdf');
+    await input.setInputFiles(src);
+    const btn = page.locator(`button:has-text("${profile}")`);
+    if (await btn.count()) {
+      await btn.click();
+    }
+    const download = await page.waitForEvent('download');
+    const dest = path.join(outDir, `${profile}-img-heavy.pdf`);
+    await download.saveAs(dest);
+    const delta = percentDelta(getFileSize(src), getFileSize(dest));
+    if (profile === 'max') expect(delta).toBeLessThanOrEqual(-40);
+    else if (profile === 'balanced') expect(delta).toBeLessThanOrEqual(-20);
+    else expect(delta).toBeLessThan(10);
+  });
+
+  test(`vector-only does not inflate for ${profile}`, async ({ page }) => {
+    await page.goto('/compress');
+    const input = page.locator('input[type=file]').first();
+    const src = path.join(fixtures, 'vector-only.pdf');
+    await input.setInputFiles(src);
+    const btn = page.locator(`button:has-text("${profile}")`);
+    if (await btn.count()) {
+      await btn.click();
+    }
+    const download = await page.waitForEvent('download');
+    const dest = path.join(outDir, `${profile}-vector-only.pdf`);
+    await download.saveAs(dest);
+    const delta = percentDelta(getFileSize(src), getFileSize(dest));
+    expect(delta).toBeLessThan(10);
+  });
+}
+

--- a/e2e/tests/merge.spec.ts
+++ b/e2e/tests/merge.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+import { getPdfText } from '../utils/pdf';
+
+const fixtures = path.join('e2e', 'fixtures', 'out');
+const outDir = path.join('e2e', '.artifacts', 'merge');
+fs.mkdirSync(outDir, { recursive: true });
+
+test('merge preserves file order', async ({ page }) => {
+  await page.goto('/merge');
+  const input = page.locator('input[type=file]').first();
+  await input.setInputFiles([
+    path.join(fixtures, 'portfolio-A.pdf'),
+    path.join(fixtures, 'portfolio-B.pdf')
+  ]);
+  const mergeBtn = page.locator('button:has-text("Merge")').first();
+  await mergeBtn.click();
+  const download = await page.waitForEvent('download');
+  const dest = path.join(outDir, 'merged.pdf');
+  await download.saveAs(dest);
+
+  const text = await getPdfText(fs.readFileSync(dest));
+  const order = ['FILE_A_P1', 'FILE_A_P2', 'FILE_B_P1', 'FILE_B_P2'];
+  for (const o of order) {
+    expect(text).toContain(o);
+  }
+  expect(text.indexOf('FILE_A_P2')).toBeLessThan(text.indexOf('FILE_B_P1'));
+});
+

--- a/e2e/tests/ocr.spec.ts
+++ b/e2e/tests/ocr.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+import { getPdfText } from '../utils/pdf';
+
+const fixtures = path.join('e2e', 'fixtures', 'out');
+const outDir = path.join('e2e', '.artifacts', 'ocr');
+fs.mkdirSync(outDir, { recursive: true });
+
+test('ocr extracts text', async ({ page }) => {
+  await page.goto('/ocr');
+  const input = page.locator('input[type=file]').first();
+  await input.setInputFiles(path.join(fixtures, 'scanned-like.pdf'));
+  const btn = page.locator('button:has-text("OCR")').first();
+  await btn.click();
+  const download = await page.waitForEvent('download');
+  const dest = path.join(outDir, download.suggestedFilename());
+  await download.saveAs(dest);
+  let text: string;
+  if (dest.endsWith('.txt')) {
+    text = fs.readFileSync(dest, 'utf8');
+  } else {
+    text = await getPdfText(fs.readFileSync(dest));
+  }
+  expect(text).toContain('THE QUICK BROWN FOX 12345');
+});
+

--- a/e2e/tests/routing.trust-pages.spec.ts
+++ b/e2e/tests/routing.trust-pages.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+const PATHS = ['/privacy', '/terms', '/about'];
+
+test('trust pages render with header and footer', async ({ page }) => {
+  for (const p of PATHS) {
+    const res = await page.goto(p);
+    if (!res || res.status() >= 400) continue;
+    await expect(page.locator('header')).toBeVisible();
+    await expect(page.locator('footer')).toBeVisible();
+    expect(res.status()).toBeLessThan(400);
+  }
+});
+

--- a/e2e/tests/split.spec.ts
+++ b/e2e/tests/split.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+import { getPdfText } from '../utils/pdf';
+
+const fixtures = path.join('e2e', 'fixtures', 'out');
+const outDir = path.join('e2e', '.artifacts', 'split');
+fs.mkdirSync(outDir, { recursive: true });
+
+test('split extracts specified page', async ({ page }) => {
+  const res = await page.goto('/split');
+  if (!res || res.status() >= 400) {
+    test.skip();
+  }
+  const input = page.locator('input[type=file]').first();
+  await input.setInputFiles(path.join(fixtures, 'portfolio-A.pdf'));
+  const rangeInput = page.locator('input').nth(1);
+  if (await rangeInput.count()) {
+    await rangeInput.fill('2');
+  }
+  const btn = page.locator('button:has-text("Split")').first();
+  await btn.click();
+  const download = await page.waitForEvent('download');
+  const dest = path.join(outDir, 'page2.pdf');
+  await download.saveAs(dest);
+  const text = await getPdfText(fs.readFileSync(dest));
+  expect(text).toContain('FILE_A_P2');
+});
+

--- a/e2e/tests/ui.english-only.spec.ts
+++ b/e2e/tests/ui.english-only.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import { hasNonAscii } from '../utils/pdf';
+
+const PATHS = ['/', '/compress', '/merge', '/ocr', '/ats', '/split'];
+
+test('UI displays only ASCII characters', async ({ page }) => {
+  const violations: string[] = [];
+
+  for (const p of PATHS) {
+    await page.goto(p);
+    const texts = await page.locator('body').allTextContents();
+    for (const t of texts) {
+      if (hasNonAscii(t)) violations.push(t.trim());
+    }
+  }
+
+  expect(violations.slice(0, 10)).toEqual([]);
+});
+

--- a/e2e/tests/upload.validation.spec.ts
+++ b/e2e/tests/upload.validation.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('non PDF upload displays error', async ({ page }) => {
+  await page.goto('/compress');
+  const input = page.locator('input[type=file]').first();
+  await input.setInputFiles('e2e/fixtures/out/not-a-pdf.txt');
+  const err = page.locator('text=PDF');
+  await expect(err.first()).toBeVisible();
+});
+

--- a/e2e/utils/pdf.ts
+++ b/e2e/utils/pdf.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import path from 'path';
+import * as pdfjs from 'pdfjs-dist';
+
+export async function getPdfText(buffer: Buffer): Promise<string> {
+  const loadingTask = pdfjs.getDocument({ data: buffer });
+  const pdf = await loadingTask.promise;
+  let text = '';
+  for (let i = 1; i <= pdf.numPages; i++) {
+    const page = await pdf.getPage(i);
+    const content = await page.getTextContent();
+    for (const item of content.items as any[]) {
+      if ('str' in item) text += item.str + ' ';
+    }
+  }
+  return text.trim();
+}
+
+export function getFileSize(p: string): number {
+  return fs.statSync(p).size;
+}
+
+export function assertContains(text: string, substring: string) {
+  if (!text.includes(substring)) {
+    throw new Error(`Expected text to contain "${substring}"`);
+  }
+}
+
+export function hasNonAscii(str: string): boolean {
+  return /[^\x00-\x7F]/.test(str);
+}
+
+export function percentDelta(a: number, b: number): number {
+  return ((b - a) / a) * 100;
+}
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
+    "preview": "vite preview --strictPort --port 4173",
     "lint": "eslint . --ext .ts,.tsx --max-warnings=0",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "ascii:fix": "node scripts/ascii-fix.mjs",
@@ -15,7 +15,14 @@
     "test:smoke:full": "playwright test",
     "postinstall": "playwright install --with-deps || true",
     "size": "node scripts/size-guard.mjs",
-    "audit": "node scripts/audit.mjs"
+    "audit": "node scripts/audit.mjs",
+    "gen:fixtures": "tsx e2e/fixtures/generate-fixtures.ts",
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed",
+    "preview:start": "tsx e2e/scripts/preview-start.ts",
+    "preview:stop": "tsx e2e/scripts/preview-stop.ts",
+    "tool:status": "tsx e2e/scripts/tool-status.ts",
+    "qa:local": "run-s gen:fixtures build preview:start e2e tool:status preview:stop"
   },
   "dependencies": {
     "jspdf": "^2.5.1",
@@ -28,6 +35,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.41.2",
+    "playwright": "^1.41.2",
     "@types/jspdf": "^2.0.0",
     "@types/node": "^20.8.4",
     "@types/react": "^18.2.37",
@@ -42,7 +50,11 @@
     "typescript": "^5.2.2",
     "vitest": "^1.2.0",
     "vite": "^5.0.0",
-    "vite-tsconfig-paths": "^4.0.5"
+    "vite-tsconfig-paths": "^4.0.5",
+    "tsx": "^4.7.0",
+    "jimp": "^0.22.10",
+    "zod": "^3.22.4",
+    "npm-run-all": "^4.1.5"
   },
   "engines": {
     "node": ">=18.18"


### PR DESCRIPTION
## Summary
- add Playwright-based QA harness and helper utilities
- generate PDF fixtures programmatically
- add end-to-end tests for compress, merge, OCR, ATS export and more
- wire up GitHub Actions workflow to run QA suite

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config file)


------
https://chatgpt.com/codex/tasks/task_e_68a347530b94832f98bd7888fa3888ab