### PR TITLE
fix: use ESM worker format

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,10 +11,11 @@ export default defineConfig({
     dedupe: ["react", "react-dom"],
   },
   worker: {
-    format: "es",
+    // Workers must use an ESM format to allow code-splitting
+    format: "esm",
     rollupOptions: {
       output: {
-        format: "es",
+        format: "esm",
       },
     },
   },


### PR DESCRIPTION
## Summary
- build workers using ESM output to avoid code-splitting error

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vite/client')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aab8d3fba4832fbcd3dc252b7940e2